### PR TITLE
Fix process not defined for browsers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# dash-platform-sdk v1.0.3
+# dash-platform-sdk v1.0.4
 [![GitHub license](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/pshenmic/dash-platform-sdk/blob/master/LICENSE) ![npm version](https://img.shields.io/npm/v/react.svg?style=flat) ![a](https://github.com/pshenmic/platform-explorer/actions/workflows/build.yml/badge.svg)
 
 
@@ -25,7 +25,7 @@ $ npm install dash-platform-sdk
 
 Alternatively, you could simply include the library from the CDN:
 
-https://unpkg.com/dash-platform-sdk@1.0.3/dist/main.js
+https://unpkg.com/dash-platform-sdk@1.0.4/dist/main.js
 
 ## Quickstart
 To use the SDK, simply import the library and instantiate an instance of DashPlatformSDK:
@@ -42,7 +42,7 @@ const sdk = new DashPlatformSDK({network: 'testnet'})
 Or load it straight from the web page:
 
 ```html
-<script src="https://unpkg.com/dash-platform-sdk@1.0.3/dist/main.js"></script>
+<script src="https://unpkg.com/dash-platform-sdk@1.0.4/dist/main.js"></script>
 <script>
     const sdk = new DashPlatformSDK({network: 'testnet'})
 </script>

--- a/package.json
+++ b/package.json
@@ -6,11 +6,13 @@
     "@babel/core": "^7.26.10",
     "@babel/preset-env": "^7.26.9",
     "babel-jest": "^29.7.0",
+    "buffer": "^6.0.3",
     "grpc-tools": "^1.13.0",
     "grpc_tools_node_protoc_ts": "^5.3.3",
     "isomorphic-ws": "^5.0.0",
     "jest": "^29.7.0",
     "nice-grpc-web": "^3.3.6",
+    "process": "^0.11.10",
     "standard": "^17.1.2",
     "stream-browserify": "^3.0.0",
     "terser-webpack-plugin": "^5.3.14",
@@ -20,7 +22,6 @@
     "typescript": "^5.8.2",
     "webpack": "^5.98.0",
     "webpack-cli": "^6.0.1",
-    "buffer": "^6.0.3",
     "ws": "^8.18.1"
   },
   "scripts": {
@@ -37,6 +38,5 @@
     "cbor": "^10.0.3",
     "pshenmic-dpp": "^1.0.3",
     "rfc4648": "^1.5.4"
-  },
-  "packageManager": "yarn@1.22.19+sha1.4ba7fc5c6e704fce2066ecbfb0b0d8976fe62447"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dash-platform-sdk",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "main": "dist/main.js",
   "devDependencies": {
     "@babel/core": "^7.26.10",

--- a/src/index.js
+++ b/src/index.js
@@ -15,6 +15,10 @@ import fromDocument from './stateTransitions/fromDocument'
 import broadcastStateTransition from './stateTransitions/broadcast'
 import waitForStateTransitionResult from './stateTransitions/waitForStateTransitionResult'
 import { base64 } from "rfc4648";
+import hexToUint8Array from './utils/hexToUint8Array'
+import base58ToUint8Array from './utils/base58ToUint8Array'
+import convertToHomographSafeChars from './utils/convertToHomographSafeChars'
+import uint8ArrayToBase58 from './utils/uint8ArrayToBase58'
 
 const DEFAULT_OPTIONS = {
   network: 'testnet'
@@ -60,6 +64,13 @@ export default class DashPlatformSDK {
 
     this.node = {
       status: status.bind(this)
+    }
+
+    this.utils = {
+      hexToUint8Array,
+      base58ToUint8Array,
+      uint8ArrayToBase58,
+      convertToHomographSafeChars
     }
   }
 }

--- a/src/utils/base58ToUint8Array.js
+++ b/src/utils/base58ToUint8Array.js
@@ -1,0 +1,5 @@
+import { base58 } from '@scure/base'
+
+export default function stringToBase58 (string) {
+  return base58.decode(string)
+}

--- a/src/utils/uint8ArrayToBase58.js
+++ b/src/utils/uint8ArrayToBase58.js
@@ -1,0 +1,5 @@
+import { base58 } from '@scure/base'
+
+export default function uint8ArrayToBase58 (uint8Array) {
+  return base58.encode(uint8Array)
+}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,4 +1,5 @@
 const path = require('path')
+const webpack = require('webpack')
 const TerserPlugin = require('terser-webpack-plugin')
 
 module.exports = {
@@ -14,6 +15,12 @@ module.exports = {
       }),
     ]
   },
+  plugins: [
+    // fix "process is not defined" error:
+    new webpack.ProvidePlugin({
+      process: 'process/browser',
+    }),
+  ],
   resolve: {
     fallback: {
       stream: require.resolve('stream-browserify'),

--- a/yarn.lock
+++ b/yarn.lock
@@ -4435,6 +4435,11 @@ pretty-format@^29.7.0:
     ansi-styles "^5.0.0"
     react-is "^18.0.0"
 
+process@^0.11.10:
+  version "0.11.10"
+  resolved "https://registry.yarnpkg.com/process/-/process-0.11.10.tgz#7332300e840161bda3e69a1d1d91a7d4bc16f182"
+  integrity sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==
+
 prompts@^2.0.1:
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/prompts/-/prompts-2.4.2.tgz#7b57e73b3a48029ad10ebd44f74b01722a4cb069"


### PR DESCRIPTION
# Issue

When executing `sdk.documents.query` there is a error in browser environment attempting to read Node.js global variable `process` that should be polyfilled for Browsers

# Things done

* Added webpack.ProvidePlugin with `process/browser`
* Added utils functions in SDK (for easier conversions)