### PR TITLE
Bump non-create document revisions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# dash-platform-sdk v1.0.5
+# dash-platform-sdk v1.0.6
 [![GitHub license](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/pshenmic/dash-platform-sdk/blob/master/LICENSE) ![npm version](https://img.shields.io/npm/v/react.svg?style=flat) ![a](https://github.com/pshenmic/platform-explorer/actions/workflows/build.yml/badge.svg)
 
 

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "dashkeys": "^1.1.5",
     "dashphrase": "^1.4.0",
     "grpc-web": "^1.5.0",
-    "pshenmic-dpp": "1.0.7-rc.1",
+    "pshenmic-dpp": "1.0.7-rc.3",
     "rfc4648": "^1.5.4"
   },
   "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dash-platform-sdk",
-  "version": "1.0.6-rc.1",
+  "version": "1.0.6-rc.2",
   "main": "dist/main.js",
   "types": "dist/types.d.ts",
   "description": "Lightweight SDK for accessing Dash Platform blockchain",

--- a/src/stateTransitions/batch/document/create.ts
+++ b/src/stateTransitions/batch/document/create.ts
@@ -1,7 +1,7 @@
 import { DocumentWASM, StateTransitionWASM } from 'pshenmic-dpp'
 
 export default async function (document: DocumentWASM, identityContractNonce: bigint): Promise<StateTransitionWASM> {
-  const createTransition = new this.dpp.DocumentCreateTransitionWASM(document, identityContractNonce, document.getDocumentTypeName())
+  const createTransition = new this.dpp.DocumentCreateTransitionWASM(document, identityContractNonce)
 
   const documentTransition = createTransition.toDocumentTransition()
 

--- a/src/stateTransitions/batch/document/delete.ts
+++ b/src/stateTransitions/batch/document/delete.ts
@@ -1,6 +1,7 @@
 import { DocumentWASM, StateTransitionWASM } from 'pshenmic-dpp'
 
 export default async function (document: DocumentWASM, identityContractNonce: bigint): Promise<StateTransitionWASM> {
+  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
   document.setRevision(document.getRevision()! + BigInt(1))
 
   const deleteTransition = new this.dpp.DocumentDeleteTransitionWASM(document, identityContractNonce, document.getDocumentTypeName())

--- a/src/stateTransitions/batch/document/delete.ts
+++ b/src/stateTransitions/batch/document/delete.ts
@@ -4,7 +4,7 @@ export default async function (document: DocumentWASM, identityContractNonce: bi
   // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
   document.setRevision(document.getRevision()! + BigInt(1))
 
-  const deleteTransition = new this.dpp.DocumentDeleteTransitionWASM(document, identityContractNonce, document.getDocumentTypeName())
+  const deleteTransition = new this.dpp.DocumentDeleteTransitionWASM(document, identityContractNonce)
 
   const documentTransition = deleteTransition.toDocumentTransition()
 

--- a/src/stateTransitions/batch/document/delete.ts
+++ b/src/stateTransitions/batch/document/delete.ts
@@ -1,6 +1,8 @@
 import { DocumentWASM, StateTransitionWASM } from 'pshenmic-dpp'
 
 export default async function (document: DocumentWASM, identityContractNonce: bigint): Promise<StateTransitionWASM> {
+  document.setRevision(document.getRevision()! + BigInt(1))
+
   const deleteTransition = new this.dpp.DocumentDeleteTransitionWASM(document, identityContractNonce, document.getDocumentTypeName())
 
   const documentTransition = deleteTransition.toDocumentTransition()

--- a/src/stateTransitions/batch/document/purchase.ts
+++ b/src/stateTransitions/batch/document/purchase.ts
@@ -1,7 +1,8 @@
 import { DocumentWASM, StateTransitionWASM } from 'pshenmic-dpp'
-import {IdentifierLike} from "../../../types";
+import { IdentifierLike } from '../../../types'
 
 export default async function (document: DocumentWASM, ownerId: IdentifierLike, identityContractNonce: bigint, price: bigint): Promise<StateTransitionWASM> {
+  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
   document.setRevision(document.getRevision()! + BigInt(1))
 
   const deleteTransition = new this.dpp.DocumentPurchaseTransitionWASM(document, identityContractNonce, document.getDocumentTypeName(), price)

--- a/src/stateTransitions/batch/document/purchase.ts
+++ b/src/stateTransitions/batch/document/purchase.ts
@@ -2,6 +2,8 @@ import { DocumentWASM, StateTransitionWASM } from 'pshenmic-dpp'
 import {IdentifierLike} from "../../../types";
 
 export default async function (document: DocumentWASM, ownerId: IdentifierLike, identityContractNonce: bigint, price: bigint): Promise<StateTransitionWASM> {
+  document.setRevision(document.getRevision()! + BigInt(1))
+
   const deleteTransition = new this.dpp.DocumentPurchaseTransitionWASM(document, identityContractNonce, document.getDocumentTypeName(), price)
 
   const documentTransition = deleteTransition.toDocumentTransition()

--- a/src/stateTransitions/batch/document/purchase.ts
+++ b/src/stateTransitions/batch/document/purchase.ts
@@ -5,7 +5,7 @@ export default async function (document: DocumentWASM, ownerId: IdentifierLike, 
   // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
   document.setRevision(document.getRevision()! + BigInt(1))
 
-  const deleteTransition = new this.dpp.DocumentPurchaseTransitionWASM(document, identityContractNonce, document.getDocumentTypeName(), price)
+  const deleteTransition = new this.dpp.DocumentPurchaseTransitionWASM(document, identityContractNonce, price)
 
   const documentTransition = deleteTransition.toDocumentTransition()
 

--- a/src/stateTransitions/batch/document/replace.ts
+++ b/src/stateTransitions/batch/document/replace.ts
@@ -1,6 +1,8 @@
-import { DocumentWASM, StateTransitionWASM } from 'pshenmic-dpp'
+import {DocumentWASM, StateTransitionWASM} from 'pshenmic-dpp'
 
 export default async function (document: DocumentWASM, identityContractNonce: bigint): Promise<StateTransitionWASM> {
+  document.setRevision(document.getRevision()! + BigInt(1))
+
   const replaceTransition = new this.dpp.DocumentReplaceTransitionWASM(document, identityContractNonce, document.getDocumentTypeName())
 
   const documentTransition = replaceTransition.toDocumentTransition()

--- a/src/stateTransitions/batch/document/replace.ts
+++ b/src/stateTransitions/batch/document/replace.ts
@@ -1,6 +1,7 @@
-import {DocumentWASM, StateTransitionWASM} from 'pshenmic-dpp'
+import { DocumentWASM, StateTransitionWASM } from 'pshenmic-dpp'
 
 export default async function (document: DocumentWASM, identityContractNonce: bigint): Promise<StateTransitionWASM> {
+  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
   document.setRevision(document.getRevision()! + BigInt(1))
 
   const replaceTransition = new this.dpp.DocumentReplaceTransitionWASM(document, identityContractNonce, document.getDocumentTypeName())

--- a/src/stateTransitions/batch/document/replace.ts
+++ b/src/stateTransitions/batch/document/replace.ts
@@ -4,7 +4,7 @@ export default async function (document: DocumentWASM, identityContractNonce: bi
   // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
   document.setRevision(document.getRevision()! + BigInt(1))
 
-  const replaceTransition = new this.dpp.DocumentReplaceTransitionWASM(document, identityContractNonce, document.getDocumentTypeName())
+  const replaceTransition = new this.dpp.DocumentReplaceTransitionWASM(document, identityContractNonce)
 
   const documentTransition = replaceTransition.toDocumentTransition()
 

--- a/src/stateTransitions/batch/document/transfer.ts
+++ b/src/stateTransitions/batch/document/transfer.ts
@@ -1,7 +1,8 @@
 import { DocumentWASM, StateTransitionWASM } from 'pshenmic-dpp'
-import {IdentifierLike} from "../../../types";
+import { IdentifierLike } from '../../../types'
 
 export default async function (document: DocumentWASM, identityContractNonce: bigint, recipient: IdentifierLike): Promise<StateTransitionWASM> {
+  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
   document.setRevision(document.getRevision()! + BigInt(1))
 
   const deleteTransition = new this.dpp.DocumentTransferTransitionWASM(document, identityContractNonce, document.getDocumentTypeName(), recipient)

--- a/src/stateTransitions/batch/document/transfer.ts
+++ b/src/stateTransitions/batch/document/transfer.ts
@@ -5,7 +5,7 @@ export default async function (document: DocumentWASM, identityContractNonce: bi
   // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
   document.setRevision(document.getRevision()! + BigInt(1))
 
-  const deleteTransition = new this.dpp.DocumentTransferTransitionWASM(document, identityContractNonce, document.getDocumentTypeName(), recipient)
+  const deleteTransition = new this.dpp.DocumentTransferTransitionWASM(document, identityContractNonce, recipient)
 
   const documentTransition = deleteTransition.toDocumentTransition()
 

--- a/src/stateTransitions/batch/document/transfer.ts
+++ b/src/stateTransitions/batch/document/transfer.ts
@@ -2,6 +2,8 @@ import { DocumentWASM, StateTransitionWASM } from 'pshenmic-dpp'
 import {IdentifierLike} from "../../../types";
 
 export default async function (document: DocumentWASM, identityContractNonce: bigint, recipient: IdentifierLike): Promise<StateTransitionWASM> {
+  document.setRevision(document.getRevision()! + BigInt(1))
+
   const deleteTransition = new this.dpp.DocumentTransferTransitionWASM(document, identityContractNonce, document.getDocumentTypeName(), recipient)
 
   const documentTransition = deleteTransition.toDocumentTransition()

--- a/src/stateTransitions/batch/document/updatePrice.ts
+++ b/src/stateTransitions/batch/document/updatePrice.ts
@@ -1,6 +1,8 @@
 import { DocumentWASM, StateTransitionWASM } from 'pshenmic-dpp'
 
 export default async function (document: DocumentWASM, identityContractNonce: bigint, price: bigint): Promise<StateTransitionWASM> {
+  document.setRevision(document.getRevision()! + BigInt(1))
+
   const updatePriceTransition = new this.dpp.DocumentUpdatePriceTransitionWASM(document, identityContractNonce, document.getDocumentTypeName(), price)
 
   const documentTransition = updatePriceTransition.toDocumentTransition()

--- a/src/stateTransitions/batch/document/updatePrice.ts
+++ b/src/stateTransitions/batch/document/updatePrice.ts
@@ -4,7 +4,7 @@ export default async function (document: DocumentWASM, identityContractNonce: bi
   // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
   document.setRevision(document.getRevision()! + BigInt(1))
 
-  const updatePriceTransition = new this.dpp.DocumentUpdatePriceTransitionWASM(document, identityContractNonce, document.getDocumentTypeName(), price)
+  const updatePriceTransition = new this.dpp.DocumentUpdatePriceTransitionWASM(document, identityContractNonce, price)
 
   const documentTransition = updatePriceTransition.toDocumentTransition()
 

--- a/src/stateTransitions/batch/document/updatePrice.ts
+++ b/src/stateTransitions/batch/document/updatePrice.ts
@@ -1,6 +1,7 @@
 import { DocumentWASM, StateTransitionWASM } from 'pshenmic-dpp'
 
 export default async function (document: DocumentWASM, identityContractNonce: bigint, price: bigint): Promise<StateTransitionWASM> {
+  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
   document.setRevision(document.getRevision()! + BigInt(1))
 
   const updatePriceTransition = new this.dpp.DocumentUpdatePriceTransitionWASM(document, identityContractNonce, document.getDocumentTypeName(), price)

--- a/src/stateTransitions/broadcast.ts
+++ b/src/stateTransitions/broadcast.ts
@@ -3,7 +3,7 @@ import { StateTransitionWASM } from 'pshenmic-dpp'
 
 export default async function broadcast (stateTransition: StateTransitionWASM): Promise<void> {
   const broadcastStateTransitionRequest = BroadcastStateTransitionRequest.fromPartial({
-    stateTransition: stateTransition.toBytes()
+    stateTransition: stateTransition.bytes()
   })
 
   await this.grpcPool.getClient().broadcastStateTransition(broadcastStateTransitionRequest)

--- a/src/types.ts
+++ b/src/types.ts
@@ -16,7 +16,7 @@ import {
 import { Utils as DashHdUtils } from 'dashhd'
 export type IdentifierLike = IdentifierWASM | string | ArrayLike<number>
 
-export {DashPlatformSDK} from './index'
+export { DashPlatformSDK } from './index'
 export type DocumentTransitionLike = DocumentCreateTransitionWASM | DocumentDeleteTransitionWASM | DocumentPurchaseTransitionWASM | DocumentReplaceTransitionWASM | DocumentTransferTransitionWASM | DocumentUpdatePriceTransitionWASM
 
 export type MasternodeList = Record<string, MasternodeInfo>
@@ -202,7 +202,7 @@ export interface Signer {
 }
 
 export interface AbstractSigner {
-  connect() : void
-  getCurrentIdentity() : IdentityWASM
-  signStateTransition(stateTransition: StateTransitionWASM, identity: IdentityWASM): void
+  connect: () => void
+  getCurrentIdentity: () => IdentityWASM
+  signStateTransition: (stateTransition: StateTransitionWASM, identity: IdentityWASM) => void
 }

--- a/test/unit/Document.spec.ts
+++ b/test/unit/Document.spec.ts
@@ -31,6 +31,7 @@ describe('Document', () => {
 
     const [document] = await sdk.documents.query(dataContract, documentType)
 
+    expect(document.getDataContractId().base58()).toEqual(dataContract)
     expect(document).toEqual(expect.any(DocumentWASM))
   })
 })

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,5 +7,9 @@
     "strictNullChecks": true,
     "emitDeclarationOnly": false
   },
-  "include": ["./src/index.ts"]
+  "include": [
+    "./src/**/*",
+    "./types/**/*",
+    "./test/**/*",
+  ]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4719,10 +4719,10 @@ prop-types@^15.8.1:
     object-assign "^4.1.1"
     react-is "^16.13.1"
 
-pshenmic-dpp@1.0.7-rc.1:
-  version "1.0.7-rc.1"
-  resolved "https://registry.yarnpkg.com/pshenmic-dpp/-/pshenmic-dpp-1.0.7-rc.1.tgz#54d0c8fd77fac5f4548250dd83635e6da090f9ce"
-  integrity sha512-VbKMo91fmuCbrp9Itt/egmI7yWfZyVVe5Ming8GhRPUxfiky07Db5BPKuJ5ZbiNP1CTXodoHQbCH3K4SWOoV1A==
+pshenmic-dpp@1.0.7-rc.3:
+  version "1.0.7-rc.3"
+  resolved "https://registry.yarnpkg.com/pshenmic-dpp/-/pshenmic-dpp-1.0.7-rc.3.tgz#0b63a8920a569fc7d8ee5d364ada98438054a5bf"
+  integrity sha512-kKF38Zv3Ot2E5gc3kJdNH5Zc/ZysPaqUzfxAwjH5v342Lhal73Bqpusn4zJcJlnsOY4erBIgQxeTOhIAh5kZ3A==
 
 punycode@^2.1.0:
   version "2.3.1"


### PR DESCRIPTION
# Issue

Document revisions was not bumped and lead to a broadcast transition error


# Things done
* Upgraded to newer pshenmic-dpp version
* Added revision increment in all non create document transition
* Bump version