### PR TITLE
Ci Pre-Release support

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,6 +16,13 @@ jobs:
       - run: yarn build:grpc
       - run: yarn test
       - run: yarn build
-      - run: yarn publish
+      - run: |
+          VERSION=$(node -p "require('./package.json').version")
+          if [[ "$VERSION" == *"-"* ]]; then
+            TAG=$(echo "$VERSION" | sed -E 's/^[0-9]+\.[0-9]+\.[0-9]+-([a-zA-Z0-9]+).*/\1/')
+            yarn publish --tag "$TAG" --non-interactive
+          else
+            yarn publish --tag latest --non-interactive
+          fi
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
# Issue
At the moment, when we try to create an RC release, we get a package in npm without a pre-release tag.

# Things done
- Implemented conditions for publish and new args for publish