### PR TITLE
Add signer in the constructor

### DIFF
--- a/src/DashPlatformSDK.ts
+++ b/src/DashPlatformSDK.ts
@@ -55,7 +55,7 @@ export class DashPlatformSDK {
     this.keyPair = new KeyPairController()
   }
 
-  setSigner(signer: AbstractSigner): void {
+  setSigner (signer: AbstractSigner): void {
     this.signer = signer
   }
 

--- a/src/DashPlatformSDK.ts
+++ b/src/DashPlatformSDK.ts
@@ -28,10 +28,11 @@ export class DashPlatformSDK {
   node: NodeController
   dataContracts: DataContractsController
   names: NamesController
-  signer: AbstractSigner
+  signer?: AbstractSigner
 
-  constructor (options: { network: 'testnet' | 'mainnet', dapiUrl?: string } = DEFAULT_OPTIONS) {
+  constructor (options: { network: 'testnet' | 'mainnet', dapiUrl?: string, signer?: AbstractSigner } = DEFAULT_OPTIONS) {
     this.network = options.network
+    this.signer = options.signer
 
     this.utils = new UtilsController()
 
@@ -52,6 +53,10 @@ export class DashPlatformSDK {
     this.names = new NamesController(grpcPool)
     this.node = new NodeController(grpcPool)
     this.keyPair = new KeyPairController()
+  }
+
+  setSigner(signer: AbstractSigner): void {
+    this.signer = signer
   }
 
   setNetwork (network: 'testnet' | 'mainnet'): void {

--- a/src/documents/createStateTransition.ts
+++ b/src/documents/createStateTransition.ts
@@ -8,20 +8,7 @@ import {
   DocumentUpdatePriceTransitionWASM,
   DocumentWASM, StateTransitionWASM
 } from 'pshenmic-dpp'
-
-export interface DocumentBatchTransitionPurchaseParams {
-  price: bigint | null
-}
-
-export interface DocumentBatchTransitionTransferParams {
-  recipient: string | null
-}
-
-export interface DocumentBatchTransitionUpdatePriceParams {
-  price: bigint | null
-}
-
-export type CreateStateTransitionDocumentBatchParams = DocumentBatchTransitionPurchaseParams | DocumentBatchTransitionTransferParams | DocumentBatchTransitionUpdatePriceParams
+import {CreateStateTransitionDocumentBatchParams} from "../types";
 
 const documentBatchTypesMap = {
   [BatchType.Create]: DocumentCreateTransitionWASM,

--- a/src/documents/createStateTransition.ts
+++ b/src/documents/createStateTransition.ts
@@ -8,7 +8,7 @@ import {
   DocumentUpdatePriceTransitionWASM,
   DocumentWASM, StateTransitionWASM
 } from 'pshenmic-dpp'
-import {CreateStateTransitionDocumentBatchParams} from "../types";
+import { CreateStateTransitionDocumentBatchParams } from '../types'
 
 const documentBatchTypesMap = {
   [BatchType.Create]: DocumentCreateTransitionWASM,

--- a/src/documents/index.ts
+++ b/src/documents/index.ts
@@ -1,8 +1,8 @@
 import get from './get'
-import { IdentifierLike } from '../types'
+import { CreateStateTransitionDocumentBatchParams, IdentifierLike } from '../types'
 import createDocument from './create'
 import { BatchType, DocumentWASM, IdentifierWASM, StateTransitionWASM } from 'pshenmic-dpp'
-import createStateTransition, { CreateStateTransitionDocumentBatchParams } from './createStateTransition'
+import createStateTransition from './createStateTransition'
 import GRPCConnectionPool from '../grpcConnectionPool'
 
 export class DocumentsController {

--- a/src/types.ts
+++ b/src/types.ts
@@ -13,6 +13,20 @@ export interface WalletToIdentityKeyOpts {
   network?: 'mainnet' | 'testnet'
 }
 
+export type CreateStateTransitionDocumentBatchParams = DocumentBatchTransitionPurchaseParams | DocumentBatchTransitionTransferParams | DocumentBatchTransitionUpdatePriceParams
+
+export interface DocumentBatchTransitionPurchaseParams {
+  price: bigint | null
+}
+
+export interface DocumentBatchTransitionTransferParams {
+  recipient: string | null
+}
+
+export interface DocumentBatchTransitionUpdatePriceParams {
+  price: bigint | null
+}
+
 export interface MasternodeInfo {
   proTxHash: string
   address: string


### PR DESCRIPTION
# Issue

We want to be able to set AbstractSigner in the sdk and let developers imlpement their own signer implementation to use with SDK

# Things done
* Added `signer` in the constructor, and add setSigner() setter on DashPlatformSDK
