### PR TITLE
Add missing runtime dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
     "grpc_tools_node_protoc_ts": "^5.3.3",
     "isomorphic-ws": "^5.0.0",
     "jest": "^29.7.0",
-    "nice-grpc-web": "^3.3.6",
     "process": "^0.11.10",
     "stream-browserify": "^3.0.0",
     "terser-webpack-plugin": "^5.3.14",
@@ -43,9 +42,9 @@
     "proto:generate": "grpc_tools_node_protoc --plugin=protoc-gen-ts_proto=./node_modules/.bin/protoc-gen-ts_proto --ts_proto_out=./proto/generated --ts_proto_opt=useAsyncIterable=false --ts_proto_opt=forceLong=string,env=browser,outputServices=grpc-web,outputServices=generic-definitions,outputJsonMethods=false,useExactTypes=false --proto_path=./proto ./proto/platform.proto"
   },
   "dependencies": {
+    "@bufbuild/protobuf": "^2.6.0",
     "@dashincubator/secp256k1": "^1.7.1-5",
     "@noble/curves": "^1.9.2",
-    "wasm-drive-verify": "github:owl352/wasm-drive-verify#fe2a9406609ee2a9d42a6b4be7214395bd164155",
     "@scure/base": "^1.2.4",
     "cbor-x": "^1.6.0",
     "dashhd": "^3.3.3",
@@ -53,7 +52,9 @@
     "dashphrase": "^1.4.0",
     "grpc-web": "^1.5.0",
     "hash.js": "^1.1.7",
+    "nice-grpc-web": "^3.3.6",
     "pshenmic-dpp": "1.0.9",
-    "rfc4648": "^1.5.4"
+    "rfc4648": "^1.5.4",
+    "wasm-drive-verify": "github:owl352/wasm-drive-verify#fe2a9406609ee2a9d42a6b4be7214395bd164155"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -931,7 +931,7 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@bufbuild/protobuf@^2.0.0":
+"@bufbuild/protobuf@^2.0.0", "@bufbuild/protobuf@^2.6.0":
   version "2.6.0"
   resolved "https://registry.yarnpkg.com/@bufbuild/protobuf/-/protobuf-2.6.0.tgz#82f10cbd2eff47b1e9196967749b26f916b808e8"
   integrity sha512-6cuonJVNOIL7lTj5zgo/Rc2bKAo4/GvN+rKCrUj7GdEHRzCk8zKOfFwUsL9nAVk5rSIsRmlgcpLzTRysopEeeg==


### PR DESCRIPTION
# Issue

Few dependencies are missing from the package.json leading to failed build if you're building it yourself outside the project

# Things done

* Added @bufbuild/protobuf and nice-grpc-web in the package.json
* Updated yarn lock