### PR TITLE
Fix main entrypoint in package.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# dash-platform-sdk v1.1.0
+# dash-platform-sdk v1.1.1
 [![GitHub license](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/pshenmic/dash-platform-sdk/blob/master/LICENSE) ![npm version](https://img.shields.io/npm/v/react.svg?style=flat) ![a](https://github.com/pshenmic/platform-explorer/actions/workflows/build.yml/badge.svg)
 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dash-platform-sdk",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "main": "index.js",
   "description": "Lightweight SDK for accessing Dash Platform blockchain",
   "ts-standard": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dash-platform-sdk",
   "version": "1.1.0",
-  "main": "dist/index.js",
+  "main": "index.js",
   "description": "Lightweight SDK for accessing Dash Platform blockchain",
   "ts-standard": {
     "ignore": [


### PR DESCRIPTION
# Issue

During tests of SDK in different projects, we figured out the correct approach of typescript bindings and correct package.json parameters during refactor. Recently, I moved out files in the NPM packages out of the `dist` directory, but accidentally forgot to update the main module path in package.json.

# Things done
* Updated pacakge.json main property from `dist/index.js` to `index.js`