### PR TITLE
Token action transitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# dash-platform-sdk v1.1.4
+# dash-platform-sdk v1.1.5
 [![GitHub license](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/pshenmic/dash-platform-sdk/blob/master/LICENSE) ![npm version](https://img.shields.io/npm/v/react.svg?style=flat) ![a](https://github.com/pshenmic/platform-explorer/actions/workflows/build.yml/badge.svg)
 
 

--- a/README.md
+++ b/README.md
@@ -409,7 +409,6 @@ const amount = BigInt(10000)
 const privateKey = 'deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef'
 const publicKeyId = 5
 
-
 const tokenBaseTransition = await sdk.tokens.createBaseTransition(tokenId, owner)
 const stateTransition = sdk.tokens.createStateTransition(tokenBaseTransition, owner, 'transfer', { identityId: recipient, amount })
 

--- a/README.md
+++ b/README.md
@@ -395,6 +395,29 @@ const updatePriceTransition = await sdk.documents.createStateTransition(
   { price: BigInt(200) }
 )
 ```
+### Token State Transitions
+#### Transfer token
+
+This method allows to transfer a token to an identity
+
+```javascript
+const owner = 'HT3pUBM1Uv2mKgdPEN1gxa7A4PdsvNY89aJbdSKQb5wR'
+const recipient = '8GopLQQCViyroS2gHktesGaCMe2tueXWeQ6Y9vpMFTEC'
+const tokenId = '6niNoQpsT9zyVDJtXcbpV3tR3qEGi6BC6xoDdJyx1u7C'
+const amount = BigInt(10000)
+
+const privateKey = 'deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef'
+const publicKeyId = 5
+
+
+const tokenBaseTransition = await sdk.tokens.createBaseTransition(tokenId, owner)
+const stateTransition = sdk.tokens.createStateTransition(tokenBaseTransition, owner, 'transfer', { identityId: recipient, amount })
+
+stateTransition.signByPrivateKey(PrivateKeyWASM.fromHex(privateKey, 'testnet'), 'ECDSA_SECP256K1')
+stateTransition.signaturePublicKeyId = publicKeyId
+
+await sdk.stateTransitions.broadcast(stateTransition)
+```
 
 ### Identities
 #### Get identity by identifier

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dash-platform-sdk",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "main": "index.js",
   "description": "Lightweight SDK for accessing Dash Platform blockchain",
   "ts-standard": {

--- a/src/tokens/createStateTransition.ts
+++ b/src/tokens/createStateTransition.ts
@@ -49,17 +49,11 @@ const tokenTransitionsMap = {
     arguments: ['identityId', 'publicNote'],
     optionalArguments: ['publicNote'],
   },
-  claim: {
-    class: TokenClaimTransitionWASM,
-    arguments: ['distributionType', 'publicNote'],
-    optionalArguments: ['publicNote'],
-  },
   emergencyAction: {
     class: TokenEmergencyActionTransitionWASM,
     arguments: ['emergencyAction', 'publicNote'],
     optionalArguments: ['publicNote'],
   },
-  // configUpdate: TokenConfigUpdateTransitionWASM,
   directPurchase: {
     class: TokenDirectPurchaseTransitionWASM,
     arguments: ['tokenCount', 'totalAgreedPrice'],

--- a/src/tokens/createStateTransition.ts
+++ b/src/tokens/createStateTransition.ts
@@ -54,7 +54,7 @@ const tokenTransitionsMap = {
   },
   directPurchase: {
     class: TokenDirectPurchaseTransitionWASM,
-    arguments: ['tokenCount', 'totalAgreedPrice'],
+    arguments: ['amount', 'totalAgreedPrice'],
     optionalArguments: []
   },
   setPriceForDirectPurchase: {
@@ -77,7 +77,7 @@ export default function createStateTransition (base: TokenBaseTransitionWASM, ow
           !(optionalArguments as string[]).includes(classArgument))
 
   if (missingArgument != null) {
-    throw new Error(`Token transition param ${missingArgument} is missing`)
+    throw new Error(`Token transition param "${missingArgument}" is missing`)
   }
 
   const transitionParams = classArguments.map((classArgument: string) => params[classArgument])

--- a/src/tokens/createStateTransition.ts
+++ b/src/tokens/createStateTransition.ts
@@ -5,18 +5,16 @@ import {
   StateTransitionWASM,
   TokenBaseTransitionWASM,
   TokenBurnTransitionWASM,
-  TokenClaimTransitionWASM,
   TokenDestroyFrozenFundsTransitionWASM,
   TokenDirectPurchaseTransitionWASM,
   TokenEmergencyActionTransitionWASM,
-  TokenEmergencyActionWASM,
   TokenFreezeTransitionWASM,
   TokenMintTransitionWASM,
   TokenSetPriceForDirectPurchaseTransitionWASM,
   TokenTransferTransitionWASM, TokenTransitionWASM,
   TokenUnFreezeTransitionWASM
 } from 'pshenmic-dpp'
-import {TokenTransitionParams, TokenTransitionType} from "../types";
+import { TokenTransitionParams, TokenTransitionType } from '../types'
 
 const tokenTransitionsMap = {
   burn: {
@@ -37,37 +35,37 @@ const tokenTransitionsMap = {
   freeze: {
     class: TokenFreezeTransitionWASM,
     arguments: ['identityId', 'publicNote'],
-    optionalArguments: ['publicNote'],
+    optionalArguments: ['publicNote']
   },
   unfreeze: {
     class: TokenUnFreezeTransitionWASM,
     arguments: ['identityId', 'publicNote'],
-    optionalArguments: ['publicNote'],
+    optionalArguments: ['publicNote']
   },
   destroyFrozenFunds: {
     class: TokenDestroyFrozenFundsTransitionWASM,
     arguments: ['identityId', 'publicNote'],
-    optionalArguments: ['publicNote'],
+    optionalArguments: ['publicNote']
   },
   emergencyAction: {
     class: TokenEmergencyActionTransitionWASM,
     arguments: ['emergencyAction', 'publicNote'],
-    optionalArguments: ['publicNote'],
+    optionalArguments: ['publicNote']
   },
   directPurchase: {
     class: TokenDirectPurchaseTransitionWASM,
     arguments: ['tokenCount', 'totalAgreedPrice'],
-    optionalArguments: [],
+    optionalArguments: []
   },
   setPriceForDirectPurchase: {
     class: TokenSetPriceForDirectPurchaseTransitionWASM,
     arguments: ['price', 'publicNote'],
-    optionalArguments: ['publicNote'],
+    optionalArguments: ['publicNote']
   }
 }
 
 export default function createStateTransition (base: TokenBaseTransitionWASM, ownerId: IdentifierWASM, type: TokenTransitionType, params: TokenTransitionParams): StateTransitionWASM {
-  const {class: TransitionClass, arguments: classArguments, optionalArguments } = tokenTransitionsMap[type]
+  const { class: TransitionClass, arguments: classArguments, optionalArguments } = tokenTransitionsMap[type]
 
   if (TransitionClass == null) {
     throw new Error(`Unimplemented transition type: ${type}`)
@@ -75,7 +73,7 @@ export default function createStateTransition (base: TokenBaseTransitionWASM, ow
 
   // check if all required params for token transition exists
   const [missingArgument] = classArguments
-      .filter((classArgument: string) => params[classArgument] == null &&
+    .filter((classArgument: string) => params[classArgument] == null &&
           !(optionalArguments as string[]).includes(classArgument))
 
   if (missingArgument != null) {

--- a/src/tokens/createStateTransition.ts
+++ b/src/tokens/createStateTransition.ts
@@ -1,0 +1,101 @@
+import {
+  BatchedTransitionWASM,
+  BatchTransitionWASM,
+  IdentifierWASM,
+  StateTransitionWASM,
+  TokenBaseTransitionWASM,
+  TokenBurnTransitionWASM,
+  TokenClaimTransitionWASM,
+  TokenDestroyFrozenFundsTransitionWASM,
+  TokenDirectPurchaseTransitionWASM,
+  TokenEmergencyActionTransitionWASM,
+  TokenEmergencyActionWASM,
+  TokenFreezeTransitionWASM,
+  TokenMintTransitionWASM,
+  TokenSetPriceForDirectPurchaseTransitionWASM,
+  TokenTransferTransitionWASM, TokenTransitionWASM,
+  TokenUnFreezeTransitionWASM
+} from 'pshenmic-dpp'
+import {TokenTransitionParams, TokenTransitionType} from "../types";
+
+const tokenTransitionsMap = {
+  burn: {
+    class: TokenBurnTransitionWASM,
+    arguments: ['amount', 'publicNote'],
+    optionalArguments: ['publicNote']
+  },
+  mint: {
+    class: TokenMintTransitionWASM,
+    arguments: ['identityId', 'amount', 'publicNote'],
+    optionalArguments: ['publicNote']
+  },
+  transfer: {
+    class: TokenTransferTransitionWASM,
+    arguments: ['identityId', 'amount', 'publicNote', 'sharedEncryptedNote', 'privateEncryptedNote'],
+    optionalArguments: ['publicNote', 'sharedEncryptedNote', 'privateEncryptedNote']
+  },
+  freeze: {
+    class: TokenFreezeTransitionWASM,
+    arguments: ['identityId', 'publicNote'],
+    optionalArguments: ['publicNote'],
+  },
+  unfreeze: {
+    class: TokenUnFreezeTransitionWASM,
+    arguments: ['identityId', 'publicNote'],
+    optionalArguments: ['publicNote'],
+  },
+  destroyFrozenFunds: {
+    class: TokenDestroyFrozenFundsTransitionWASM,
+    arguments: ['identityId', 'publicNote'],
+    optionalArguments: ['publicNote'],
+  },
+  claim: {
+    class: TokenClaimTransitionWASM,
+    arguments: ['distributionType', 'publicNote'],
+    optionalArguments: ['publicNote'],
+  },
+  emergencyAction: {
+    class: TokenEmergencyActionTransitionWASM,
+    arguments: ['emergencyAction', 'publicNote'],
+    optionalArguments: ['publicNote'],
+  },
+  // configUpdate: TokenConfigUpdateTransitionWASM,
+  directPurchase: {
+    class: TokenDirectPurchaseTransitionWASM,
+    arguments: ['tokenCount', 'totalAgreedPrice'],
+    optionalArguments: [],
+  },
+  setPriceForDirectPurchase: {
+    class: TokenSetPriceForDirectPurchaseTransitionWASM,
+    arguments: ['price', 'publicNote'],
+    optionalArguments: ['publicNote'],
+  }
+}
+
+export default function createStateTransition (base: TokenBaseTransitionWASM, ownerId: IdentifierWASM, type: TokenTransitionType, params: TokenTransitionParams): StateTransitionWASM {
+  const {class: TransitionClass, arguments: classArguments, optionalArguments } = tokenTransitionsMap[type]
+
+  if (TransitionClass == null) {
+    throw new Error(`Unimplemented transition type: ${type}`)
+  }
+
+  // check if all required params for token transition exists
+  const [missingArgument] = classArguments
+      .filter((classArgument: string) => params[classArgument] == null &&
+          !(optionalArguments as string[]).includes(classArgument))
+
+  if (missingArgument != null) {
+    throw new Error(`Token transition param ${missingArgument} is missing`)
+  }
+
+  const transitionParams = classArguments.map((classArgument: string) => params[classArgument])
+
+  // @ts-expect-error
+  const tokenTransition = new TransitionClass(base, ...transitionParams)
+
+  const tokenTransitionWASM = new TokenTransitionWASM(tokenTransition)
+
+  const batchedTransition = new BatchedTransitionWASM(tokenTransitionWASM)
+
+  return BatchTransitionWASM.fromV1BatchedTransitions([batchedTransition], ownerId, 1).toStateTransition()
+}

--- a/src/tokens/getTokenContractInfo.ts
+++ b/src/tokens/getTokenContractInfo.ts
@@ -4,14 +4,14 @@ import {
   GetTokenContractInfoResponse_GetTokenContractInfoResponseV0
 } from '../../proto/generated/platform'
 import { IdentifierLike } from '../types'
-import { IdentifierWASM, PlatformVersionWASM } from 'pshenmic-dpp'
+import {IdentifierWASM, PlatformVersionWASM, TokenBaseTransitionWASM} from 'pshenmic-dpp'
 import { verifyTokenContractInfo } from 'wasm-drive-verify'
 import { getQuorumPublicKey } from '../utils/getQuorumPublicKey'
 import bytesToHex from '../utils/bytesToHex'
 import verifyTenderdashProof from '../utils/verifyTenderdashProof'
 
 export interface TokenContractInfo {
-  contractId: IdentifierWASM
+  dataContractId: IdentifierWASM
   tokenContractPosition: number
 }
 
@@ -60,7 +60,7 @@ export default async function getTokenContractInfo (grpcPool: GRPCConnectionPool
   }
 
   return {
-    contractId: new IdentifierWASM(contractInfo.contractId),
+    dataContractId: new IdentifierWASM(contractInfo.contractId),
     tokenContractPosition: contractInfo.tokenContractPosition
   }
 }

--- a/src/tokens/getTokenContractInfo.ts
+++ b/src/tokens/getTokenContractInfo.ts
@@ -4,7 +4,7 @@ import {
   GetTokenContractInfoResponse_GetTokenContractInfoResponseV0
 } from '../../proto/generated/platform'
 import { IdentifierLike } from '../types'
-import {IdentifierWASM, PlatformVersionWASM, TokenBaseTransitionWASM} from 'pshenmic-dpp'
+import { IdentifierWASM, PlatformVersionWASM } from 'pshenmic-dpp'
 import { verifyTokenContractInfo } from 'wasm-drive-verify'
 import { getQuorumPublicKey } from '../utils/getQuorumPublicKey'
 import bytesToHex from '../utils/bytesToHex'

--- a/src/tokens/index.ts
+++ b/src/tokens/index.ts
@@ -1,12 +1,12 @@
 import GRPCConnectionPool from '../grpcConnectionPool'
-import {IdentifierLike, TokenTransitionParams, TokenTransitionType} from '../types'
-import getIdentitiesTokenBalances, {IdentitiesTokenBalances} from './getIdentitiesTokenBalances'
-import getIdentityTokensBalances, {IdentityTokenBalances} from './getIdentityTokensBalances'
-import getTokenContractInfo, {TokenContractInfo} from './getTokenContractInfo'
-import getTokenTotalSupply, {TokenTotalSupply} from './getTokenTotalSupply'
+import { IdentifierLike, TokenTransitionParams, TokenTransitionType } from '../types'
+import getIdentitiesTokenBalances, { IdentitiesTokenBalances } from './getIdentitiesTokenBalances'
+import getIdentityTokensBalances, { IdentityTokenBalances } from './getIdentityTokensBalances'
+import getTokenContractInfo, { TokenContractInfo } from './getTokenContractInfo'
+import getTokenTotalSupply, { TokenTotalSupply } from './getTokenTotalSupply'
 import createStateTransition from './createStateTransition'
-import {IdentifierWASM, StateTransitionWASM, TokenBaseTransitionWASM} from "pshenmic-dpp";
-import getIdentityContractNonce from "../identities/getIdentityContractNonce";
+import { IdentifierWASM, StateTransitionWASM, TokenBaseTransitionWASM } from 'pshenmic-dpp'
+import getIdentityContractNonce from '../identities/getIdentityContractNonce'
 
 /**
  * Tokens controller for requesting information about tokens and tokens holders
@@ -76,7 +76,7 @@ export default class TokensController {
    * @return {TokenBaseTransitionWASM}
    */
   async createBaseTransition (tokenId: IdentifierLike, ownerId: IdentifierLike): Promise<TokenBaseTransitionWASM> {
-    const { dataContractId, tokenContractPosition} = await getTokenContractInfo(this.grpcPool, tokenId)
+    const { dataContractId, tokenContractPosition } = await getTokenContractInfo(this.grpcPool, tokenId)
     const identityContractNonce = await getIdentityContractNonce(this.grpcPool, ownerId, dataContractId)
 
     return new TokenBaseTransitionWASM(identityContractNonce, tokenContractPosition, dataContractId, tokenId, undefined)

--- a/src/tokens/index.ts
+++ b/src/tokens/index.ts
@@ -5,7 +5,7 @@ import getIdentityTokensBalances, { IdentityTokenBalances } from './getIdentityT
 import getTokenContractInfo, { TokenContractInfo } from './getTokenContractInfo'
 import getTokenTotalSupply, { TokenTotalSupply } from './getTokenTotalSupply'
 import createStateTransition from './createStateTransition'
-import { IdentifierWASM, StateTransitionWASM, TokenBaseTransitionWASM } from 'pshenmic-dpp'
+import { IdentifierWASM, StateTransitionWASM, TokenBaseTransitionWASM, TokenPricingScheduleWASM } from 'pshenmic-dpp'
 import getIdentityContractNonce from '../identities/getIdentityContractNonce'
 
 /**
@@ -100,6 +100,10 @@ export default class TokensController {
 
     if (params.identityId != null) {
       params.identityId = new IdentifierWASM(params.identityId)
+    }
+
+    if (params.price != null && typeof params.price === 'bigint') {
+      params.price = TokenPricingScheduleWASM.SinglePrice(params.price)
     }
 
     return createStateTransition(base, owner, type, params)

--- a/src/tokens/index.ts
+++ b/src/tokens/index.ts
@@ -68,10 +68,10 @@ export default class TokensController {
   }
 
   /**
-   * Creates a token state transition
+   * Creates a Token Base Transition that contains base information about token transition
    *
-   * @param tokenId {IdentifierLike} - token id which total supply we need
-   * @param ownerId {IdentifierLike} - token id which total supply we need
+   * @param tokenId {IdentifierLike} - token identifier
+   * @param ownerId {IdentifierLike} - identity identifier of sender of the transaction
    *
    * @return {TokenBaseTransitionWASM}
    */
@@ -79,16 +79,19 @@ export default class TokensController {
     const { dataContractId, tokenContractPosition } = await getTokenContractInfo(this.grpcPool, tokenId)
     const identityContractNonce = await getIdentityContractNonce(this.grpcPool, ownerId, dataContractId)
 
-    return new TokenBaseTransitionWASM(identityContractNonce, tokenContractPosition, dataContractId, tokenId, undefined)
+    return new TokenBaseTransitionWASM(identityContractNonce + BigInt(1), tokenContractPosition, dataContractId, tokenId, undefined)
   }
 
   /**
-   * Creates a token state transition
+   * Helper function for creation of a token state transition to be broadcasted in the network
    *
-   * @param base {TokenBaseTransitionWASM} - token id which total supply we need
-   * @param ownerId {IdentifierLike} - token id which total supply we need
-   * @param type {TokenTransitionType} - token id which total supply we need
-   * @param params {TokenTransitionParams} - token id which total supply we need
+   * You have to pass token base transition acquired from .createBaseTransition() method
+   * together with token transition type and its params
+   *
+   * @param base {TokenBaseTransitionWASM} - token Base transition
+   * @param ownerId {IdentifierLike} - `identity identifier of the owner of the transaction`
+   * @param type {TokenTransitionType} - token transition type as string (f.e. 'transfer')
+   * @param params {TokenTransitionParams} - params required for a token transition
    *
    * @return {StateTransitionWASM}
    */

--- a/src/types.ts
+++ b/src/types.ts
@@ -167,11 +167,11 @@ export interface DataContractConfig {
 export type TokenTransitionType = 'burn' | 'mint' | 'transfer' | 'freeze' | 'unfreeze' | 'destroyFrozenFunds' | 'emergencyAction' | 'directPurchase' | 'setPriceForDirectPurchase'
 
 export interface TokenTransitionParams {
-  identityId?: IdentifierLike,
-  amount?: bigint,
-  totalAgreedPrice?: bigint,
-  publicNote?: string,
-  sharedEncryptedNote?: string,
+  identityId?: IdentifierLike
+  amount?: bigint
+  totalAgreedPrice?: bigint
+  publicNote?: string
+  sharedEncryptedNote?: string
   privateEncryptedNote?: string
   emergencyAction?: TokenEmergencyActionWASM
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,5 @@
 import {
-  IdentifierWASM, TokenEmergencyActionWASM
+  IdentifierWASM, TokenEmergencyActionWASM, TokenPricingScheduleWASM
 } from 'pshenmic-dpp'
 
 import { Versions } from 'dashhd'
@@ -169,6 +169,7 @@ export type TokenTransitionType = 'burn' | 'mint' | 'transfer' | 'freeze' | 'unf
 export interface TokenTransitionParams {
   identityId?: IdentifierLike
   amount?: bigint
+  price?: bigint | TokenPricingScheduleWASM
   totalAgreedPrice?: bigint
   publicNote?: string
   sharedEncryptedNote?: string

--- a/src/types.ts
+++ b/src/types.ts
@@ -164,7 +164,7 @@ export interface DataContractConfig {
   requiresIdentityDecryptionBoundedKey?: number | null
 }
 
-export type TokenTransitionType = 'burn' | 'mint' | 'transfer' | 'freeze' | 'unfreeze' | 'destroyFrozenFunds' | 'claim' | 'emergencyAction' | 'directPurchase' | 'setPriceForDirectPurchase'
+export type TokenTransitionType = 'burn' | 'mint' | 'transfer' | 'freeze' | 'unfreeze' | 'destroyFrozenFunds' | 'emergencyAction' | 'directPurchase' | 'setPriceForDirectPurchase'
 
 export interface TokenTransitionParams {
   identityId?: IdentifierLike,

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,5 @@
 import {
-  IdentifierWASM
+  IdentifierWASM, TokenEmergencyActionWASM
 } from 'pshenmic-dpp'
 
 import { Versions } from 'dashhd'
@@ -162,4 +162,16 @@ export interface DataContractConfig {
   documentsCanBeDeletedContractDefault: boolean
   requiresIdentityEncryptionBoundedKey?: number | null
   requiresIdentityDecryptionBoundedKey?: number | null
+}
+
+export type TokenTransitionType = 'burn' | 'mint' | 'transfer' | 'freeze' | 'unfreeze' | 'destroyFrozenFunds' | 'claim' | 'emergencyAction' | 'directPurchase' | 'setPriceForDirectPurchase'
+
+export interface TokenTransitionParams {
+  identityId?: IdentifierLike,
+  amount?: bigint,
+  totalAgreedPrice?: bigint,
+  publicNote?: string,
+  sharedEncryptedNote?: string,
+  privateEncryptedNote?: string
+  emergencyAction?: TokenEmergencyActionWASM
 }

--- a/test/unit/Tokens.spec.ts
+++ b/test/unit/Tokens.spec.ts
@@ -53,12 +53,7 @@ describe('Tokens', () => {
 
     const stateTransition = sdk.tokens.createStateTransition(tokenBaseTransition, owner, 'transfer', { identityId: recipient, amount: BigInt(1000) })
 
-    stateTransition.signByPrivateKey(PrivateKeyWASM.fromHex('c20acd0a04f838b267016243bed301286bc918de2a93d114a552285293c7ba66', 'testnet'), 'ECDSA_SECP256K1')
-    stateTransition.signaturePublicKeyId = 5
-
     expect(stateTransition).toBeInstanceOf(StateTransitionWASM)
-
-    console.log(stateTransition.base64())
   })
 
   // test('should be able to create transfer transition', async () => {

--- a/test/unit/Tokens.spec.ts
+++ b/test/unit/Tokens.spec.ts
@@ -1,5 +1,5 @@
 import { DashPlatformSDK } from '../../src/types'
-import { StateTransitionWASM, TokenBaseTransitionWASM } from 'pshenmic-dpp'
+import { StateTransitionWASM, TokenBaseTransitionWASM, TokenEmergencyActionWASM } from 'pshenmic-dpp'
 
 let sdk: DashPlatformSDK
 
@@ -45,14 +45,123 @@ describe('Tokens', () => {
     expect(tokenBaseTransition).toBeInstanceOf(TokenBaseTransitionWASM)
   })
 
-  test('should be able to create transfer transition', async () => {
-    const owner = 'HT3pUBM1Uv2mKgdPEN1gxa7A4PdsvNY89aJbdSKQb5wR'
-    const recipient = '8GopLQQCViyroS2gHktesGaCMe2tueXWeQ6Y9vpMFTEC'
-    const tokenId = '6niNoQpsT9zyVDJtXcbpV3tR3qEGi6BC6xoDdJyx1u7C'
-    const tokenBaseTransition = await sdk.tokens.createBaseTransition(tokenId, owner)
+  describe('create state transitions', () => {
+    test('should be able to create burn transition', async () => {
+      const tokenId = '6niNoQpsT9zyVDJtXcbpV3tR3qEGi6BC6xoDdJyx1u7C'
+      const owner = 'HT3pUBM1Uv2mKgdPEN1gxa7A4PdsvNY89aJbdSKQb5wR'
 
-    const stateTransition = sdk.tokens.createStateTransition(tokenBaseTransition, owner, 'transfer', { identityId: recipient, amount: BigInt(1000) })
+      const amount = BigInt(10)
 
-    expect(stateTransition).toBeInstanceOf(StateTransitionWASM)
+      const tokenBaseTransition = await sdk.tokens.createBaseTransition(tokenId, owner)
+
+      const stateTransition = sdk.tokens.createStateTransition(tokenBaseTransition, owner, 'burn', { amount })
+
+      expect(stateTransition).toBeInstanceOf(StateTransitionWASM)
+    })
+
+    test('should be able to create mint transition', async () => {
+      const tokenId = '6niNoQpsT9zyVDJtXcbpV3tR3qEGi6BC6xoDdJyx1u7C'
+      const owner = 'HT3pUBM1Uv2mKgdPEN1gxa7A4PdsvNY89aJbdSKQb5wR'
+
+      const recipientId = '8GopLQQCViyroS2gHktesGaCMe2tueXWeQ6Y9vpMFTEC'
+      const amount = BigInt(10)
+
+      const tokenBaseTransition = await sdk.tokens.createBaseTransition(tokenId, owner)
+
+      const stateTransition = sdk.tokens.createStateTransition(tokenBaseTransition, owner, 'mint', { identityId: recipientId, amount })
+
+      expect(stateTransition).toBeInstanceOf(StateTransitionWASM)
+    })
+
+    test('should be able to create transfer transition', async () => {
+      const tokenId = '6niNoQpsT9zyVDJtXcbpV3tR3qEGi6BC6xoDdJyx1u7C'
+      const owner = 'HT3pUBM1Uv2mKgdPEN1gxa7A4PdsvNY89aJbdSKQb5wR'
+
+      const recipient = '8GopLQQCViyroS2gHktesGaCMe2tueXWeQ6Y9vpMFTEC'
+      const amount = BigInt(100)
+
+      const tokenBaseTransition = await sdk.tokens.createBaseTransition(tokenId, owner)
+
+      const stateTransition = sdk.tokens.createStateTransition(tokenBaseTransition, owner, 'transfer', { identityId: recipient, amount })
+
+      expect(stateTransition).toBeInstanceOf(StateTransitionWASM)
+    })
+
+    test('should be able to create freeze transition', async () => {
+      const tokenId = '6niNoQpsT9zyVDJtXcbpV3tR3qEGi6BC6xoDdJyx1u7C'
+      const owner = 'HT3pUBM1Uv2mKgdPEN1gxa7A4PdsvNY89aJbdSKQb5wR'
+
+      const identityId = '8GopLQQCViyroS2gHktesGaCMe2tueXWeQ6Y9vpMFTEC'
+
+      const tokenBaseTransition = await sdk.tokens.createBaseTransition(tokenId, owner)
+
+      const stateTransition = sdk.tokens.createStateTransition(tokenBaseTransition, owner, 'freeze', { identityId })
+
+      expect(stateTransition).toBeInstanceOf(StateTransitionWASM)
+    })
+
+    test('should be able to create unfreeze transition', async () => {
+      const tokenId = '6niNoQpsT9zyVDJtXcbpV3tR3qEGi6BC6xoDdJyx1u7C'
+      const owner = 'HT3pUBM1Uv2mKgdPEN1gxa7A4PdsvNY89aJbdSKQb5wR'
+
+      const identityId = '8GopLQQCViyroS2gHktesGaCMe2tueXWeQ6Y9vpMFTEC'
+      const tokenBaseTransition = await sdk.tokens.createBaseTransition(tokenId, owner)
+
+      const stateTransition = sdk.tokens.createStateTransition(tokenBaseTransition, owner, 'unfreeze', { identityId })
+
+      expect(stateTransition).toBeInstanceOf(StateTransitionWASM)
+    })
+
+    test('should be able to create destroyFrozenFunds transition', async () => {
+      const tokenId = '6niNoQpsT9zyVDJtXcbpV3tR3qEGi6BC6xoDdJyx1u7C'
+      const owner = 'HT3pUBM1Uv2mKgdPEN1gxa7A4PdsvNY89aJbdSKQb5wR'
+
+      const identityId = '8GopLQQCViyroS2gHktesGaCMe2tueXWeQ6Y9vpMFTEC'
+
+      const tokenBaseTransition = await sdk.tokens.createBaseTransition(tokenId, owner)
+
+      const stateTransition = sdk.tokens.createStateTransition(tokenBaseTransition, owner, 'destroyFrozenFunds', { identityId })
+
+      expect(stateTransition).toBeInstanceOf(StateTransitionWASM)
+    })
+
+    test('should be able to create emergency action transition', async () => {
+      const tokenId = '6niNoQpsT9zyVDJtXcbpV3tR3qEGi6BC6xoDdJyx1u7C'
+      const owner = 'HT3pUBM1Uv2mKgdPEN1gxa7A4PdsvNY89aJbdSKQb5wR'
+
+      const emergencyAction = TokenEmergencyActionWASM.Pause
+
+      const tokenBaseTransition = await sdk.tokens.createBaseTransition(tokenId, owner)
+
+      const stateTransition = sdk.tokens.createStateTransition(tokenBaseTransition, owner, 'emergencyAction', { emergencyAction })
+
+      expect(stateTransition).toBeInstanceOf(StateTransitionWASM)
+    })
+
+    test('should be able to create setPriceForDirectPurchase transition', async () => {
+      const tokenId = '6niNoQpsT9zyVDJtXcbpV3tR3qEGi6BC6xoDdJyx1u7C'
+      const owner = 'HT3pUBM1Uv2mKgdPEN1gxa7A4PdsvNY89aJbdSKQb5wR'
+
+      const price = BigInt(10)
+      const tokenBaseTransition = await sdk.tokens.createBaseTransition(tokenId, owner)
+
+      const stateTransition = sdk.tokens.createStateTransition(tokenBaseTransition, owner, 'setPriceForDirectPurchase', { price })
+
+      expect(stateTransition).toBeInstanceOf(StateTransitionWASM)
+    })
+
+    test('should be able to create directPurchase transition', async () => {
+      const tokenId = '6niNoQpsT9zyVDJtXcbpV3tR3qEGi6BC6xoDdJyx1u7C'
+      const owner = 'HT3pUBM1Uv2mKgdPEN1gxa7A4PdsvNY89aJbdSKQb5wR'
+
+      const amount = BigInt(10)
+      const totalAgreedPrice = BigInt(100)
+
+      const tokenBaseTransition = await sdk.tokens.createBaseTransition(tokenId, owner)
+
+      const stateTransition = sdk.tokens.createStateTransition(tokenBaseTransition, owner, 'directPurchase', { amount, totalAgreedPrice })
+
+      expect(stateTransition).toBeInstanceOf(StateTransitionWASM)
+    })
   })
 })

--- a/test/unit/Tokens.spec.ts
+++ b/test/unit/Tokens.spec.ts
@@ -55,20 +55,4 @@ describe('Tokens', () => {
 
     expect(stateTransition).toBeInstanceOf(StateTransitionWASM)
   })
-
-  // test('should be able to create transfer transition', async () => {
-  //   const owner = 'HT3pUBM1Uv2mKgdPEN1gxa7A4PdsvNY89aJbdSKQb5wR'
-  //   const recipient = '8GopLQQCViyroS2gHktesGaCMe2tueXWeQ6Y9vpMFTEC'
-  //   const tokenId = '6niNoQpsT9zyVDJtXcbpV3tR3qEGi6BC6xoDdJyx1u7C'
-  //   const tokenBaseTransition = await sdk.tokens.createBaseTransition(tokenId, owner)
-  //
-  //   const stateTransition = sdk.tokens.createStateTransition(tokenBaseTransition, owner, 'transfer', { identityId: recipient, amount: BigInt(1000) })
-  //
-  //   stateTransition.signByPrivateKey(PrivateKeyWASM.fromHex('c20acd0a04f838b267016243bed301286bc918de2a93d114a552285293c7ba66', 'testnet'), 'ECDSA_SECP256K1')
-  //   stateTransition.signaturePublicKeyId = 5
-  //
-  //   expect(stateTransition).toBeInstanceOf(StateTransitionWASM)
-  //
-  //   console.log(stateTransition.base64())
-  // })
 })

--- a/test/unit/Tokens.spec.ts
+++ b/test/unit/Tokens.spec.ts
@@ -1,4 +1,5 @@
 import { DashPlatformSDK } from '../../src/types'
+import {StateTransitionWASM, TokenBaseTransitionWASM} from "pshenmic-dpp";
 
 let sdk: DashPlatformSDK
 
@@ -18,7 +19,7 @@ describe('Tokens', () => {
   test('should be able to get token contract info', async () => {
     const tokenContractInfo = await sdk.tokens.getTokenContractInfo('9YxdbQUjJmQsmVPen95HjAU3Esj7tVkWSY2EQWT84ZQP')
 
-    expect(tokenContractInfo.contractId.base58()).toEqual('Y189uedQG3CJCuu83P3DqnG7ngQaRKz69x3gY8uDzQe')
+    expect(tokenContractInfo.dataContractId.base58()).toEqual('Y189uedQG3CJCuu83P3DqnG7ngQaRKz69x3gY8uDzQe')
     expect(tokenContractInfo.tokenContractPosition).toEqual(0)
   })
 
@@ -36,5 +37,21 @@ describe('Tokens', () => {
     expect(tokensIdentityBalance.length).toEqual(1)
     expect(tokensIdentityBalance[0].identityId).toBeTruthy()
     expect(tokensIdentityBalance[0].balance).toBeTruthy()
+  })
+
+  test('should be able to create base token transition', async () => {
+    const tokenBaseTransition = await sdk.tokens.createBaseTransition('A36eJF2kyYXwxCtJGsgbR3CTAscUFaNxZN19UqUfM1kw', '34vkjdeUTP2z798SiXqoB6EAuobh51kXYURqVa9xkujf')
+
+    expect(tokenBaseTransition).toBeInstanceOf(TokenBaseTransitionWASM)
+  })
+
+  test('should be able to create transfer transition', async () => {
+    const owner = '34vkjdeUTP2z798SiXqoB6EAuobh51kXYURqVa9xkujf'
+    const recipient = 'FQ4waDowFQXD4tJPKQM1114VSr5f8s3qAc5bT8FJkT49'
+    const tokenBaseTransition = await sdk.tokens.createBaseTransition('A36eJF2kyYXwxCtJGsgbR3CTAscUFaNxZN19UqUfM1kw', 'FQ4waDowFQXD4tJPKQM1114VSr5f8s3qAc5bT8FJkT49')
+
+    const stateTransition = sdk.tokens.createStateTransition(tokenBaseTransition, owner, 'transfer', { identityId: recipient, amount: BigInt(1000)})
+
+    expect(stateTransition).toBeInstanceOf(StateTransitionWASM)
   })
 })

--- a/test/unit/Tokens.spec.ts
+++ b/test/unit/Tokens.spec.ts
@@ -1,5 +1,5 @@
 import { DashPlatformSDK } from '../../src/types'
-import {StateTransitionWASM, TokenBaseTransitionWASM} from "pshenmic-dpp";
+import { StateTransitionWASM, TokenBaseTransitionWASM } from 'pshenmic-dpp'
 
 let sdk: DashPlatformSDK
 
@@ -50,7 +50,7 @@ describe('Tokens', () => {
     const recipient = 'FQ4waDowFQXD4tJPKQM1114VSr5f8s3qAc5bT8FJkT49'
     const tokenBaseTransition = await sdk.tokens.createBaseTransition('A36eJF2kyYXwxCtJGsgbR3CTAscUFaNxZN19UqUfM1kw', 'FQ4waDowFQXD4tJPKQM1114VSr5f8s3qAc5bT8FJkT49')
 
-    const stateTransition = sdk.tokens.createStateTransition(tokenBaseTransition, owner, 'transfer', { identityId: recipient, amount: BigInt(1000)})
+    const stateTransition = sdk.tokens.createStateTransition(tokenBaseTransition, owner, 'transfer', { identityId: recipient, amount: BigInt(1000) })
 
     expect(stateTransition).toBeInstanceOf(StateTransitionWASM)
   })

--- a/test/unit/Tokens.spec.ts
+++ b/test/unit/Tokens.spec.ts
@@ -1,5 +1,5 @@
 import { DashPlatformSDK } from '../../src/types'
-import { PrivateKeyWASM, StateTransitionWASM, TokenBaseTransitionWASM } from 'pshenmic-dpp'
+import { StateTransitionWASM, TokenBaseTransitionWASM } from 'pshenmic-dpp'
 
 let sdk: DashPlatformSDK
 

--- a/test/unit/Tokens.spec.ts
+++ b/test/unit/Tokens.spec.ts
@@ -1,5 +1,5 @@
 import { DashPlatformSDK } from '../../src/types'
-import { StateTransitionWASM, TokenBaseTransitionWASM } from 'pshenmic-dpp'
+import { PrivateKeyWASM, StateTransitionWASM, TokenBaseTransitionWASM } from 'pshenmic-dpp'
 
 let sdk: DashPlatformSDK
 
@@ -46,12 +46,34 @@ describe('Tokens', () => {
   })
 
   test('should be able to create transfer transition', async () => {
-    const owner = '34vkjdeUTP2z798SiXqoB6EAuobh51kXYURqVa9xkujf'
-    const recipient = 'FQ4waDowFQXD4tJPKQM1114VSr5f8s3qAc5bT8FJkT49'
-    const tokenBaseTransition = await sdk.tokens.createBaseTransition('A36eJF2kyYXwxCtJGsgbR3CTAscUFaNxZN19UqUfM1kw', 'FQ4waDowFQXD4tJPKQM1114VSr5f8s3qAc5bT8FJkT49')
+    const owner = 'HT3pUBM1Uv2mKgdPEN1gxa7A4PdsvNY89aJbdSKQb5wR'
+    const recipient = '8GopLQQCViyroS2gHktesGaCMe2tueXWeQ6Y9vpMFTEC'
+    const tokenId = '6niNoQpsT9zyVDJtXcbpV3tR3qEGi6BC6xoDdJyx1u7C'
+    const tokenBaseTransition = await sdk.tokens.createBaseTransition(tokenId, owner)
 
     const stateTransition = sdk.tokens.createStateTransition(tokenBaseTransition, owner, 'transfer', { identityId: recipient, amount: BigInt(1000) })
 
+    stateTransition.signByPrivateKey(PrivateKeyWASM.fromHex('c20acd0a04f838b267016243bed301286bc918de2a93d114a552285293c7ba66', 'testnet'), 'ECDSA_SECP256K1')
+    stateTransition.signaturePublicKeyId = 5
+
     expect(stateTransition).toBeInstanceOf(StateTransitionWASM)
+
+    console.log(stateTransition.base64())
   })
+
+  // test('should be able to create transfer transition', async () => {
+  //   const owner = 'HT3pUBM1Uv2mKgdPEN1gxa7A4PdsvNY89aJbdSKQb5wR'
+  //   const recipient = '8GopLQQCViyroS2gHktesGaCMe2tueXWeQ6Y9vpMFTEC'
+  //   const tokenId = '6niNoQpsT9zyVDJtXcbpV3tR3qEGi6BC6xoDdJyx1u7C'
+  //   const tokenBaseTransition = await sdk.tokens.createBaseTransition(tokenId, owner)
+  //
+  //   const stateTransition = sdk.tokens.createStateTransition(tokenBaseTransition, owner, 'transfer', { identityId: recipient, amount: BigInt(1000) })
+  //
+  //   stateTransition.signByPrivateKey(PrivateKeyWASM.fromHex('c20acd0a04f838b267016243bed301286bc918de2a93d114a552285293c7ba66', 'testnet'), 'ECDSA_SECP256K1')
+  //   stateTransition.signaturePublicKeyId = 5
+  //
+  //   expect(stateTransition).toBeInstanceOf(StateTransitionWASM)
+  //
+  //   console.log(stateTransition.base64())
+  // })
 })


### PR DESCRIPTION
# Issue
We already have several token query methods, but it is missing methods for creating token state transition, like transfer,  mint, burn, etc.

This PR implements creating token transition actions state transitions with SDK

# Things done
* Added createStateTransition() interface to TokenController
* Implemented all token transitions except TokenConfigUpdate and TokenClaim (will be implemented later)
* Updated documentation with sample token transfer method
* Bumped package version to 1.1.5

# Breaking changes

* getTokenContractInfo() renamed field from `contractId` to `dataContractId`