### PR TITLE
Invalid hash returned in the node status request

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# dash-platform-sdk v1.1.5
+# dash-platform-sdk v1.1.6
 [![GitHub license](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/pshenmic/dash-platform-sdk/blob/master/LICENSE) ![npm version](https://img.shields.io/npm/v/react.svg?style=flat) ![a](https://github.com/pshenmic/platform-explorer/actions/workflows/build.yml/badge.svg)
 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dash-platform-sdk",
-  "version": "1.1.5",
+  "version": "1.1.6",
   "main": "index.js",
   "description": "Lightweight SDK for accessing Dash Platform blockchain",
   "ts-standard": {

--- a/src/node/status.ts
+++ b/src/node/status.ts
@@ -1,6 +1,7 @@
 import { NodeStatus } from '../types'
 import { GetStatusRequest, GetStatusResponse } from '../../proto/generated/platform'
 import GRPCConnectionPool from '../grpcConnectionPool'
+import bytesToHex from '../utils/bytesToHex'
 
 export default async function status (grpcPool: GRPCConnectionPool): Promise<NodeStatus> {
   const getStatusRequest = GetStatusRequest.fromPartial({ v0: {} })
@@ -16,8 +17,8 @@ export default async function status (grpcPool: GRPCConnectionPool): Promise<Nod
   return {
     node: (v0.node != null)
       ? {
-          id: v0.node.id.reduce((acc: string, code: number) => acc + code.toString(16), ''),
-          proTxHash: v0.node.proTxHash?.reduce((acc: string, code: number) => acc + code.toString(16), '')
+          id: bytesToHex(v0.node.id),
+          proTxHash: v0.node.proTxHash != null ? bytesToHex(v0.node.proTxHash) : undefined
         }
       : undefined,
     chain: (v0.chain != null)
@@ -27,10 +28,11 @@ export default async function status (grpcPool: GRPCConnectionPool): Promise<Nod
           earliestBlockHeight: v0.chain.earliestBlockHeight,
           maxPeerBlockHeight: v0.chain.maxPeerBlockHeight,
           coreChainLockedHeight: v0.chain.coreChainLockedHeight,
-          latestBlockHash: v0.chain?.latestBlockHash.reduce((acc: string, code: number) => acc + code.toString(16), ''),
-          latestAppHash: v0.chain?.latestAppHash.reduce((acc: string, code: number) => acc + code.toString(16), ''),
-          earliestBlockHash: v0.chain?.earliestBlockHash.reduce((acc: string, code: number) => acc + code.toString(16), ''),
-          earliestAppHash: v0.chain?.earliestAppHash.reduce((acc: string, code: number) => acc + code.toString(16), '')
+          latestBlockHash: v0.chain?.latestBlockHash != null ? bytesToHex(v0.chain?.latestBlockHash) : '',
+          latestAppHash: v0.chain?.latestAppHash != null ? bytesToHex(v0.chain?.latestAppHash) : '',
+          earliestBlockHash: v0.chain?.earliestBlockHash != null ? bytesToHex(v0.chain?.earliestBlockHash) : '',
+          earliestAppHash: v0.chain?.earliestAppHash != null ? bytesToHex(v0.chain?.earliestAppHash) : ''
+
         }
       : undefined,
     version: v0.version,


### PR DESCRIPTION
# Issue

On node status request, when blockchain status like latestBlockHash is returned, an incorrect method to encode some data as hex was being used, which resulted in incorrect hashes with 62 length instead of 64.

This PR replaces custom encoding with common hexToBytes method, which is proved to work fine