### PR TITLE
Fix token data contracts query

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# dash-platform-sdk v1.1.6
+# dash-platform-sdk v1.1.7
 [![GitHub license](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/pshenmic/dash-platform-sdk/blob/master/LICENSE) ![npm version](https://img.shields.io/npm/v/react.svg?style=flat) ![a](https://github.com/pshenmic/platform-explorer/actions/workflows/build.yml/badge.svg)
 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dash-platform-sdk",
-  "version": "1.1.6",
+  "version": "1.1.7",
   "main": "index.js",
   "description": "Lightweight SDK for accessing Dash Platform blockchain",
   "ts-standard": {

--- a/src/dataContracts/getDataContractByIdentifier.ts
+++ b/src/dataContracts/getDataContractByIdentifier.ts
@@ -10,7 +10,7 @@ import { getQuorumPublicKey } from '../utils/getQuorumPublicKey'
 import bytesToHex from '../utils/bytesToHex'
 import verifyTenderdashProof from '../utils/verifyTenderdashProof'
 
-export default async function getByIdentifier (grpcPool: GRPCConnectionPool, identifier: IdentifierLike): Promise<DataContractWASM> {
+export default async function getByIdentifier (grpcPool: GRPCConnectionPool, identifier: IdentifierLike, keepHistory?: boolean): Promise<DataContractWASM> {
   const id = new IdentifierWASM(identifier)
   const getDataContractRequest = GetDataContractRequest.fromPartial({
     v0: {
@@ -34,7 +34,7 @@ export default async function getByIdentifier (grpcPool: GRPCConnectionPool, ide
   const {
     root_hash: rootHash,
     contract
-  } = verifyContract(proof.grovedbProof, undefined, true, false, id.bytes(), PlatformVersionWASM.PLATFORM_V9)
+  } = verifyContract(proof.grovedbProof, undefined, false, false, id.bytes(), 9)
 
   if (contract == null) {
     throw new Error(`Data Contract with identifier ${id.base58()} not found`)

--- a/src/dataContracts/getDataContractByIdentifier.ts
+++ b/src/dataContracts/getDataContractByIdentifier.ts
@@ -10,7 +10,7 @@ import { getQuorumPublicKey } from '../utils/getQuorumPublicKey'
 import bytesToHex from '../utils/bytesToHex'
 import verifyTenderdashProof from '../utils/verifyTenderdashProof'
 
-export default async function getByIdentifier (grpcPool: GRPCConnectionPool, identifier: IdentifierLike, keepHistory?: boolean): Promise<DataContractWASM> {
+export default async function getByIdentifier (grpcPool: GRPCConnectionPool, identifier: IdentifierLike): Promise<DataContractWASM> {
   const id = new IdentifierWASM(identifier)
   const getDataContractRequest = GetDataContractRequest.fromPartial({
     v0: {

--- a/test/unit/DataContract.spec.ts
+++ b/test/unit/DataContract.spec.ts
@@ -54,11 +54,20 @@ describe('DataContract', () => {
     // System Data Contract
     dataContract = await sdk.dataContracts.getDataContractByIdentifier('GWRSAVFMjXx8HpQFaNJMqBV7MBgMK4br5UESsB4S31Ec')
 
+    expect(dataContract).toEqual(expect.any(DataContractWASM))
+
     // User Data Contract
     dataContract = await sdk.dataContracts.getDataContractByIdentifier('Aukz296s36am6wKStoMbxm4YhC6kTpu3mERVrC7vHokP')
 
+    expect(dataContract).toEqual(expect.any(DataContractWASM))
+
     // User Data Contract with keep history
     dataContract = await sdk.dataContracts.getDataContractByIdentifier('DrEhmVJz56ukHbaFt8xLVRasnNWsrx3x8dGtcu9xg6rV')
+
+    expect(dataContract).toEqual(expect.any(DataContractWASM))
+
+    // Token Data Contract
+    dataContract = await sdk.dataContracts.getDataContractByIdentifier('3XtMFe9UPf75DAcLmLsX9CLTrLPNysNPMcnWCE1C39vm')
 
     expect(dataContract).toEqual(expect.any(DataContractWASM))
   })


### PR DESCRIPTION
# Issue

There is a problem with querying token data contract, the verification of the query fails, because it passes the wrong protocol version.

Additionally, is_proof_subset param in the verification function must be set to false

# Things done

* Fixed platformVersion and isProofSubset param when verifying getDataContract response
* Added a unit test for querying token data contract
* Bumped version to v1.1.7