### PR TITLE
Identity state transitions

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "grpc-web": "^1.5.0",
     "hash.js": "^1.1.7",
     "nice-grpc-web": "^3.3.6",
-    "pshenmic-dpp": "1.0.22",
+    "pshenmic-dpp": "1.0.23-rc.2",
     "rfc4648": "^1.5.4",
     "wasm-drive-verify": "github:owl352/wasm-drive-verify#9c572d86992d205d994cd7e0630a4bd14d284f8a"
   }

--- a/src/documents/index.ts
+++ b/src/documents/index.ts
@@ -29,8 +29,8 @@ export class DocumentsController {
    *
    * @return {DataContractWASM}
    */
-  async create (dataContractId: IdentifierLike, documentType: string, data: object, owner: IdentifierLike, revision?: bigint): Promise<DocumentWASM> {
-    return createDocument(dataContractId, documentType, data, owner, revision)
+  create (dataContractId: IdentifierLike, documentType: string, data: object, owner: IdentifierLike, revision?: bigint): DocumentWASM {
+    return createDocument(new IdentifierWASM(dataContractId), documentType, data, new IdentifierWASM(owner), revision)
   }
 
   /**
@@ -49,7 +49,7 @@ export class DocumentsController {
       throw new Error('You may only set either startAfter or startAt at once')
     }
 
-    return await query(this.grpcPool, dataContractId, documentType, where, orderBy, limit ?? 100, startAt, startAfter)
+    return await query(this.grpcPool, new IdentifierWASM(dataContractId), documentType, where, orderBy, limit ?? 100, startAt, startAfter)
   }
 
   /**

--- a/src/identities/createStateTransition.ts
+++ b/src/identities/createStateTransition.ts
@@ -1,0 +1,48 @@
+import {
+  IdentityCreateTransitionWASM,
+  IdentityTopUpTransitionWASM,
+  IdentityUpdateTransitionWASM,
+  StateTransitionWASM
+} from 'pshenmic-dpp'
+import { IdentityTransitionParams } from '../types'
+
+const identityTransitionsMap = {
+  register: {
+    class: IdentityCreateTransitionWASM,
+    arguments: ['publicKeys', 'assetLockProof'],
+    optionalArguments: ['signature', 'userFeeIncrease']
+  },
+  topUp: {
+    class: IdentityTopUpTransitionWASM,
+    arguments: ['assetLockProof', 'identityId'],
+    optionalArguments: ['userFeeIncrease']
+  },
+  update: {
+    class: IdentityUpdateTransitionWASM,
+    arguments: ['identityId', 'revision', 'identityNonce', 'addPublicKeys', 'disablePublicKeyIds'],
+    optionalArguments: ['userFeeIncrease']
+  }
+}
+
+export default function createStateTransition (type: 'register' | 'update' | 'topUp', params: IdentityTransitionParams): StateTransitionWASM {
+  const { class: TransitionClass, arguments: classArguments, optionalArguments } = identityTransitionsMap[type]
+
+  if (TransitionClass == null) {
+    throw new Error(`Unimplemented transition type: ${type}`)
+  }
+
+  const [missingArgument] = classArguments
+    .filter((classArgument: string) => params[classArgument] == null &&
+          !(optionalArguments).includes(classArgument))
+
+  if (missingArgument != null) {
+    throw new Error(`Token transition param "${missingArgument}" is missing`)
+  }
+
+  const transitionParams = classArguments.map((classArgument: string) => params[classArgument])
+
+  // @ts-expect-error
+  const identityTransition = new TransitionClass(...transitionParams)
+
+  return identityTransition.toStateTransition()
+}

--- a/src/identities/index.ts
+++ b/src/identities/index.ts
@@ -3,10 +3,11 @@ import getIdentityPublicKeys from './getIdentityPublicKeys'
 import getIdentityNonce from './getIdentityNonce'
 import getIdentityBalance from './getIdentityBalance'
 import getIdentityByPublicKeyHash from './getIdentityByPublicKeyHash'
-import { IdentifierLike } from '../types'
+import { IdentifierLike, IdentityTransitionParams } from '../types'
 import GRPCConnectionPool from '../grpcConnectionPool'
 import getIdentityByIdentifier from './getIdentityByIdentifier'
-import { IdentityPublicKeyWASM, IdentityWASM } from 'pshenmic-dpp'
+import { IdentifierWASM, IdentityPublicKeyWASM, IdentityWASM, StateTransitionWASM } from 'pshenmic-dpp'
+import createStateTransition from './createStateTransition'
 import getIdentityByNonUniquePublicKeyHash from './getIdentityByNonUniquePublicKeyHash'
 
 /**
@@ -100,5 +101,23 @@ export class IdentitiesController {
    */
   async getIdentityPublicKeys (identifier: IdentifierLike): Promise<IdentityPublicKeyWASM[]> {
     return await getIdentityPublicKeys(this.grpcPool, identifier)
+  }
+
+  /**
+   * Helper function for creating {StateTransitionWASM} for Identity transitions
+   *
+   * @param type {string} type of transition, must be a one of ('register' | 'update' | 'topUp')
+   * @param params {IdentityTransitionParams} params
+   */
+  createStateTransition (type: 'register' | 'update' | 'topUp', params: IdentityTransitionParams): StateTransitionWASM {
+    if (params.identityId != null) {
+      params.identityId = new IdentifierWASM(params.identityId)
+    }
+
+    if (params.disablePublicKeyIds == null) {
+      params.disablePublicKeyIds = []
+    }
+
+    return createStateTransition(type, params)
   }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,9 @@
 import {
-  IdentifierWASM, TokenEmergencyActionWASM, TokenPricingScheduleWASM
+  AssetLockProofWASM,
+  IdentifierWASM,
+  IdentityPublicKeyInCreationWASM,
+  TokenEmergencyActionWASM,
+  TokenPricingScheduleWASM
 } from 'pshenmic-dpp'
 
 import { Versions } from 'dashhd'
@@ -175,4 +179,16 @@ export interface TokenTransitionParams {
   sharedEncryptedNote?: string
   privateEncryptedNote?: string
   emergencyAction?: TokenEmergencyActionWASM
+}
+
+export interface IdentityTransitionParams {
+  publicKeys?: IdentityPublicKeyInCreationWASM[]
+  assetLockProof?: AssetLockProofWASM
+  signature?: Uint8Array
+  addPublicKeys?: IdentityPublicKeyInCreationWASM[]
+  disablePublicKeyIds?: number[]
+  revision?: bigint
+  identityNonce?: bigint
+  identityId?: IdentifierLike
+  userFeeIncrease?: number
 }

--- a/test/unit/Identity.spec.ts
+++ b/test/unit/Identity.spec.ts
@@ -1,6 +1,13 @@
-import { DocumentWASM, IdentityPublicKeyWASM, IdentityWASM } from 'pshenmic-dpp'
+import {
+  AssetLockProofWASM,
+  DocumentWASM,
+  IdentityPublicKeyInCreationWASM,
+  IdentityPublicKeyWASM,
+  IdentityWASM, KeyType,
+  OutPointWASM, PrivateKeyWASM, Purpose, SecurityLevel
+} from 'pshenmic-dpp'
 import { DashPlatformSDK } from '../../src/DashPlatformSDK'
-
+import hexToBytes from '../../src/utils/hexToBytes'
 let sdk: DashPlatformSDK
 
 describe('Identity', () => {
@@ -67,5 +74,153 @@ describe('Identity', () => {
     const balance = await sdk.identities.getIdentityBalance(identifier)
 
     expect(balance).toEqual(expect.any(BigInt))
+  })
+
+  describe('createStateTransition', () => {
+    test('should be able to create IdentityCreateTransition via ChainLock', async () => {
+      const assetLockPrivateKey = PrivateKeyWASM.fromHex('edd04a71bddb31e530f6c2314fd42ada333f6656bb853ece13f0577a8fd30612', 'testnet')
+      const txid = '61aede830477254876d435a317241ad46753c4b1350dc991a45ebcf19ab80a11'
+      const outputIndex = 0
+
+      const assetLockProof = AssetLockProofWASM.createChainAssetLockProof(1312590, new OutPointWASM(txid, outputIndex))
+
+      const privateKey1 = PrivateKeyWASM.fromHex('a1286dd195e2b8e1f6bdc946c56a53e0c544750d6452ddc0f4c593ef311f21af', 'testnet')
+      const identityPublicKeyInCreationWASM1 = new IdentityPublicKeyInCreationWASM(0, Purpose.AUTHENTICATION, SecurityLevel.MASTER, KeyType.ECDSA_SECP256K1, false, privateKey1.getPublicKey().bytes(), Uint8Array.from([]))
+
+      const privateKey2 = PrivateKeyWASM.fromHex('44a8195e242364b935e9d7ff2106ed109e9baf3800907f5e58a259fdfd1ca5e5', 'testnet')
+      const identityPublicKeyInCreationWASM2 = new IdentityPublicKeyInCreationWASM(1, Purpose.AUTHENTICATION, SecurityLevel.HIGH, KeyType.ECDSA_SECP256K1, false, privateKey2.getPublicKey().bytes(), Uint8Array.from([]))
+
+      let identityCreateStateTransition
+
+      // Set identity public key signature for public key 0
+      identityCreateStateTransition = sdk.identities.createStateTransition('register', {
+        publicKeys: [identityPublicKeyInCreationWASM1, identityPublicKeyInCreationWASM2],
+        assetLockProof
+      })
+      identityCreateStateTransition.signByPrivateKey(privateKey1, KeyType.ECDSA_SECP256K1)
+      identityPublicKeyInCreationWASM1.signature = identityCreateStateTransition.signature
+
+      // Set identity public key signature for public key 1
+      identityCreateStateTransition = sdk.identities.createStateTransition('register', {
+        publicKeys: [identityPublicKeyInCreationWASM1, identityPublicKeyInCreationWASM2],
+        assetLockProof
+      })
+      identityCreateStateTransition.signByPrivateKey(privateKey2, KeyType.ECDSA_SECP256K1)
+      identityPublicKeyInCreationWASM2.signature = identityCreateStateTransition.signature
+
+      // Finalize
+      identityCreateStateTransition = sdk.identities.createStateTransition('register', {
+        publicKeys: [identityPublicKeyInCreationWASM1, identityPublicKeyInCreationWASM2],
+        assetLockProof
+      })
+
+      identityCreateStateTransition.signByPrivateKey(assetLockPrivateKey, KeyType.ECDSA_SECP256K1)
+    })
+
+    test('should be able to create IdentityCreateTransition via InstantSend', async () => {
+      const assetLockPrivateKey = PrivateKeyWASM.fromHex('edd04a71bddb31e530f6c2314fd42ada333f6656bb853ece13f0577a8fd30612', 'testnet')
+      const transaction = '03000800017dada5379e34ae1b59df35ba7acb879f3afaa12fa522f4b289a34d9fa2a68825010000006b48304502210093d609f65219e0d7ee694d271c4b7460ce89d298ef3e3670d5aef957e5551ead0220085d252e16cb3aae0d4e5d371e359e844fe82db93d8e4e26b5c61dc94676b7df0121037b86a1f7a11b4cc69fc7052e5cabdc625f3db47ee283ed4b87108f2cd879521effffffff0200e1f50500000000026a004054fa02000000001976a91416bbe230f46eea86fc4bf4dd550be45dc9adfcb488ac0000000024010100e1f505000000001976a914883bccdb8bfa44e55a19a1120ff2427537f7e92488ac'
+      const instantLock = '01017dada5379e34ae1b59df35ba7acb879f3afaa12fa522f4b289a34d9fa2a688250100000060afc1323120f0a3b835dd113b3221e92dea56814369925f10dd3e8f6bcfaa6aa89ed4282521863d8eb72e7e0e7d80c86ca64cce9986ae8bb63657f43f0000009179b5d130fe69bd0f2ea7bc90e9ea904a7eeea515a2612045a70925a7c678b0b09499ea307575751e22f804c443d2e1105e1fd4e30aa894324a41cd983ffe58d5312ff8db11676bd530c6ab8af1f7d2980d356dd3c86d0386da7df70aa3a66b'
+      const outputIndex = 0
+
+      const assetLockProof = AssetLockProofWASM.createInstantAssetLockProof(hexToBytes(instantLock), hexToBytes(transaction), outputIndex)
+
+      const privateKey1 = PrivateKeyWASM.fromHex('a1286dd195e2b8e1f6bdc946c56a53e0c544750d6452ddc0f4c593ef311f21af', 'testnet')
+      const identityPublicKeyInCreationWASM1 = new IdentityPublicKeyInCreationWASM(0, Purpose.AUTHENTICATION, SecurityLevel.MASTER, KeyType.ECDSA_SECP256K1, false, privateKey1.getPublicKey().bytes(), Uint8Array.from([]))
+
+      const privateKey2 = PrivateKeyWASM.fromHex('44a8195e242364b935e9d7ff2106ed109e9baf3800907f5e58a259fdfd1ca5e5', 'testnet')
+      const identityPublicKeyInCreationWASM2 = new IdentityPublicKeyInCreationWASM(1, Purpose.AUTHENTICATION, SecurityLevel.HIGH, KeyType.ECDSA_SECP256K1, false, privateKey2.getPublicKey().bytes(), Uint8Array.from([]))
+
+      let identityCreateStateTransition
+
+      // Set identity public key signature for public key 0
+      identityCreateStateTransition = sdk.identities.createStateTransition('register', {
+        publicKeys: [identityPublicKeyInCreationWASM1, identityPublicKeyInCreationWASM2],
+        assetLockProof
+      })
+      identityCreateStateTransition.signByPrivateKey(privateKey1, KeyType.ECDSA_SECP256K1)
+      identityPublicKeyInCreationWASM1.signature = identityCreateStateTransition.signature
+
+      // Set identity public key signature for public key 1
+      identityCreateStateTransition = sdk.identities.createStateTransition('register', {
+        publicKeys: [identityPublicKeyInCreationWASM1, identityPublicKeyInCreationWASM2],
+        assetLockProof
+      })
+      identityCreateStateTransition.signByPrivateKey(privateKey2, KeyType.ECDSA_SECP256K1)
+      identityPublicKeyInCreationWASM2.signature = identityCreateStateTransition.signature
+
+      // Finalize
+      identityCreateStateTransition = sdk.identities.createStateTransition('register', {
+        publicKeys: [identityPublicKeyInCreationWASM1, identityPublicKeyInCreationWASM2],
+        assetLockProof
+      })
+
+      identityCreateStateTransition.signByPrivateKey(assetLockPrivateKey, KeyType.ECDSA_SECP256K1)
+    })
+
+    test('should be able to create IdentityTopUpTransition via InstantSend', async () => {
+      const transaction = '03000800011a468e6a7cf1c5111b09b7bca6743f2571a9bf13d2ff6d21d3d230fd1dea1e97000000006b483045022100fceb25c45e77e1a273660e4f4c9a09042fb858a57704806e14bf80a734af232a02201929893dd720cf5855e31dda577cda16df29520a9774b4f3e813a4cc468fe086012103e16ede6dc5c99f28e3a5733f47a7494992bc6ce4f98551c092645910b9888b8fffffffff0200e1f50500000000026a004054fa02000000001976a91416bbe230f46eea86fc4bf4dd550be45dc9adfcb488ac0000000024010100e1f505000000001976a9147f78813975a3282e09e284d97d93c083b202e34188ac'
+      const instantLock = '01011a468e6a7cf1c5111b09b7bca6743f2571a9bf13d2ff6d21d3d230fd1dea1e9700000000892304531821bcddfe960388f93e6e91bbae170987a5c6db33f0a4cf2d88ef148968a159512600791f94053e30f688aac43bf6e698fd78339a9ab5fd3b00000091ee77cadbf9683ca3d1fb1abcb2f561f0c745b26099fe5294885852a03a4f26770a3d437265f5f00ae21d0f681d0e1610a7ac47b6d463c3efdc5f7f922e310e6f3cd66c319e63e4f1c2cc70e97886e15485dba4f29b836bf55f0619837437e8'
+      const outputIndex = 0
+      const assetLockProof = AssetLockProofWASM.createInstantAssetLockProof(hexToBytes(instantLock), hexToBytes(transaction), outputIndex)
+
+      const assetLockPrivateKey = PrivateKeyWASM.fromHex('3ca33236ab14f6df6cf87fcbb0551544fee7dcf4f251557af02c175725764a5a', 'testnet')
+      const identityId = 'HT3pUBM1Uv2mKgdPEN1gxa7A4PdsvNY89aJbdSKQb5wR'
+
+      const identityTopUpTransaction = sdk.identities.createStateTransition('topUp', {
+        identityId,
+        assetLockProof
+      })
+
+      identityTopUpTransaction.signByPrivateKey(assetLockPrivateKey, undefined, KeyType.ECDSA_SECP256K1)
+    })
+
+    test('should be able to create IdentityTopUpTransition via ChainLock', async () => {
+      const txid = '61aede830477254876d435a317241ad46753c4b1350dc991a45ebcf19ab80a11'
+      const outputIndex = 0
+      const assetLockProof = AssetLockProofWASM.createChainAssetLockProof(1312590, new OutPointWASM(txid, outputIndex))
+
+      const assetLockPrivateKey = PrivateKeyWASM.fromHex('3ca33236ab14f6df6cf87fcbb0551544fee7dcf4f251557af02c175725764a5a', 'testnet')
+      const identityId = 'HT3pUBM1Uv2mKgdPEN1gxa7A4PdsvNY89aJbdSKQb5wR'
+
+      const identityTopUpTransaction = sdk.identities.createStateTransition('topUp', {
+        identityId,
+        assetLockProof
+      })
+
+      identityTopUpTransaction.signByPrivateKey(assetLockPrivateKey, undefined, KeyType.ECDSA_SECP256K1)
+    })
+
+    test('should be able to create IdentityUpdateTransition', async () => {
+      const identityId = 'HT3pUBM1Uv2mKgdPEN1gxa7A4PdsvNY89aJbdSKQb5wR'
+      const masterPrivateKey = PrivateKeyWASM.fromHex('16f614c6242580628d849e3616491dda1eccce99642a85667eb9a364dc85324a', 'testnet')
+      const masterKeyId = 0
+
+      const identity = await sdk.identities.getIdentityByIdentifier(identityId)
+
+      const revision = identity.revision + BigInt(1)
+      const identityNonce = await sdk.identities.getIdentityNonce(identityId) + BigInt(1)
+      const keyId = identity.getPublicKeys()[identity.getPublicKeys().length - 1].keyId + 1
+      const identityPrivateKey = PrivateKeyWASM.fromHex('16f614c6242580628d849e3616491dda1eccce99642a85667eb9a364dc85324a', 'testnet')
+      const identityPublicKeyInCreation = new IdentityPublicKeyInCreationWASM(keyId, Purpose.AUTHENTICATION, SecurityLevel.HIGH, KeyType.ECDSA_SECP256K1, false, identityPrivateKey.getPublicKey().bytes(), Uint8Array.from([]))
+
+      let identityUpdateTransition = sdk.identities.createStateTransition('update', {
+        identityId,
+        revision,
+        identityNonce,
+        addPublicKeys: [identityPublicKeyInCreation]
+      })
+      identityUpdateTransition.signByPrivateKey(masterPrivateKey, masterKeyId, KeyType.ECDSA_SECP256K1)
+      identityPublicKeyInCreation.signature = identityUpdateTransition.signature
+
+      identityUpdateTransition = sdk.identities.createStateTransition('update', {
+        identityId,
+        revision,
+        identityNonce,
+        addPublicKeys: [identityPublicKeyInCreation]
+      })
+
+      identityUpdateTransition.signByPrivateKey(masterPrivateKey, masterKeyId, KeyType.ECDSA_SECP256K1)
+    })
   })
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -5051,10 +5051,10 @@ prop-types@^15.8.1:
     object-assign "^4.1.1"
     react-is "^16.13.1"
 
-pshenmic-dpp@1.0.22:
-  version "1.0.22"
-  resolved "https://registry.yarnpkg.com/pshenmic-dpp/-/pshenmic-dpp-1.0.22.tgz#0e98d77fd4a0a923823c635fee80937ab01d5fc6"
-  integrity sha512-fwW0LU1rIT0fuJs1TbEv6JqdkU2PPZzQ/e8Id+pMUJOYJhh/QKi5kVe9F0tiXqJOzrC6ev8dSTp1DVvGFX4nyA==
+pshenmic-dpp@1.0.23-rc.2:
+  version "1.0.23-rc.2"
+  resolved "https://registry.yarnpkg.com/pshenmic-dpp/-/pshenmic-dpp-1.0.23-rc.2.tgz#a2b5d4dfa6ff66622c7fc7a1ae849847ae1fc087"
+  integrity sha512-beW3P94s6dfV8kBCY1XyG27gAjDD0HoEa6R4nKkYlyG+K141xMQw+sE4l81+eLksd6/MJwJsgBuF24DvbLf1gA==
 
 punycode.js@^2.3.1:
   version "2.3.1"


### PR DESCRIPTION
# Issue

This PR implements new `createStateTransition()` method in identities scope, that let you create IdentityCreateTransition, IdentityTopUpTransition and IdentityUpdateTransition.

# Things done
* Added `sdk.identities.createStateTransition()` method
* Implemented creation of register / topUp transactions from an AssetLockProofs
* Added IdentityUpdate transaction support for manipulation of Identities keys
* Added unit tests