### PR TITLE
Token payment info for documents (pay with tokens)

### DIFF
--- a/README.md
+++ b/README.md
@@ -331,6 +331,27 @@ const prefundedVotingBalance = { indexName, amount: contestedFee }
 const stateTransition = sdk.documents.createStateTransition(document, 'create', { identityContractNonce, prefundedVotingBalance })
 ```
 
+#### Pay with Token for a Document Transition
+Some data contracts may define a cost for a document transition to be performed in the data contract.
+
+The token cost fee can be charged from either ContractOwner or Document Owner and it is specified in the data contract schema
+
+```javascript
+// ...
+const document = sdk.documents.create(dataContract, documentType, data, identity)
+const identityContractNonce = BigInt(1)
+
+const tokenPaymentInfo = {
+  tokenContractId: '6hVQW16jyvZyGSQk2YVty4ND6bgFXozizYWnPt753uW5',
+  tokenContractPosition: 0,
+  minimumTokenCost: BigInt(1000),
+  maximumTokenCost: BigInt(100000),
+  gasFeesPaidBy: GasFeesPaidByWASM.ContractOwner
+}
+
+const stateTransition = sdk.documents.createStateTransition(document, 'create', { identityContractNonce, tokenPaymentInfo })
+```
+
 #### Query Documents
 
 Performs a query for documents and returns an array of DocumentWASM instances

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "grpc-web": "^1.5.0",
     "hash.js": "^1.1.7",
     "nice-grpc-web": "^3.3.6",
-    "pshenmic-dpp": "1.0.23-rc.2",
+    "pshenmic-dpp": "1.0.23-rc.3",
     "rfc4648": "^1.5.4",
     "wasm-drive-verify": "github:owl352/wasm-drive-verify#9c572d86992d205d994cd7e0630a4bd14d284f8a"
   }

--- a/src/documents/createStateTransition.ts
+++ b/src/documents/createStateTransition.ts
@@ -16,32 +16,32 @@ const documentTransitionsMap = {
   create: {
     class: DocumentCreateTransitionWASM,
     arguments: ['identityContractNonce'],
-    optionalArguments: ['prefundedVotingBalance']
+    optionalArguments: ['prefundedVotingBalance', 'tokenPaymentInfo']
   },
   replace: {
     class: DocumentReplaceTransitionWASM,
     arguments: ['identityContractNonce'],
-    optionalArguments: []
+    optionalArguments: ['tokenPaymentInfo']
   },
   delete: {
     class: DocumentDeleteTransitionWASM,
     arguments: ['identityContractNonce'],
-    optionalArguments: []
+    optionalArguments: ['tokenPaymentInfo']
   },
   updatePrice: {
     class: DocumentUpdatePriceTransitionWASM,
     arguments: ['identityContractNonce', 'price'],
-    optionalArguments: []
+    optionalArguments: ['tokenPaymentInfo']
   },
   transfer: {
     class: DocumentTransferTransitionWASM,
     arguments: ['identityContractNonce', 'recipientId'],
-    optionalArguments: []
+    optionalArguments: ['tokenPaymentInfo']
   },
   purchase: {
     class: DocumentPurchaseTransitionWASM,
     arguments: ['identityContractNonce', 'amount'],
-    optionalArguments: []
+    optionalArguments: ['tokenPaymentInfo']
   }
 }
 
@@ -55,7 +55,7 @@ export default function createStateTransition (document: DocumentWASM, type: 'cr
   // check if all required params for document transition exists
   const [missingArgument] = classArguments
     .filter((classArgument: string) => params[classArgument] == null &&
-          !(optionalArguments as string[]).includes(classArgument))
+          !(optionalArguments).includes(classArgument))
 
   if (missingArgument != null) {
     throw new Error(`Document transition param "${missingArgument}" is missing`)

--- a/src/documents/index.ts
+++ b/src/documents/index.ts
@@ -1,6 +1,12 @@
 import { DocumentTransitionParams, IdentifierLike } from '../types'
 import createDocument from './create'
-import { DocumentWASM, IdentifierWASM, PrefundedVotingBalanceWASM, StateTransitionWASM } from 'pshenmic-dpp'
+import {
+  DocumentWASM,
+  IdentifierWASM,
+  PrefundedVotingBalanceWASM,
+  StateTransitionWASM,
+  TokenPaymentInfoWASM
+} from 'pshenmic-dpp'
 import createStateTransition from './createStateTransition'
 import GRPCConnectionPool from '../grpcConnectionPool'
 import query from './query'
@@ -84,6 +90,13 @@ export class DocumentsController {
 
       // @ts-expect-error
       params.prefundedVotingBalance = new PrefundedVotingBalanceWASM(indexName, amount)
+    }
+
+    if (params.tokenPaymentInfo != null) {
+      const { tokenContractId, tokenContractPosition, minimumTokenCost, maximumTokenCost, gasFeesPaidBy } = params.tokenPaymentInfo
+
+      // @ts-expect-error
+      params.tokenPaymentInfo = new TokenPaymentInfoWASM(new IdentifierWASM(tokenContractId), tokenContractPosition, minimumTokenCost, maximumTokenCost, gasFeesPaidBy)
     }
 
     return createStateTransition(document, type, params)

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,5 @@
 import {
+  GasFeesPaidByWASM,
   IdentifierWASM, TokenEmergencyActionWASM, TokenPricingScheduleWASM
 } from 'pshenmic-dpp'
 
@@ -30,6 +31,13 @@ export interface DocumentTransitionParams {
   prefundedVotingBalance?: {
     indexName: string
     amount: bigint
+  }
+  tokenPaymentInfo?: {
+    tokenContractId: IdentifierLike
+    tokenContractPosition: number
+    minimumTokenCost?: bigint
+    maximumTokenCost?: bigint
+    gasFeesPaidBy: GasFeesPaidByWASM
   }
 }
 

--- a/test/unit/Document.spec.ts
+++ b/test/unit/Document.spec.ts
@@ -1,4 +1,4 @@
-import { DocumentWASM, StateTransitionWASM } from 'pshenmic-dpp'
+import { DocumentWASM, GasFeesPaidByWASM, StateTransitionWASM } from 'pshenmic-dpp'
 import { DashPlatformSDK } from '../../src/DashPlatformSDK'
 
 let sdk: DashPlatformSDK
@@ -76,6 +76,23 @@ describe('Document', () => {
       const prefundedVotingBalance = { indexName, amount: contestedFee }
 
       const stateTransition = sdk.documents.createStateTransition(document, 'create', { identityContractNonce, prefundedVotingBalance })
+
+      expect(stateTransition).toEqual(expect.any(StateTransitionWASM))
+    })
+
+    test('should be able to create a document with token payment info', async () => {
+      const document = sdk.documents.create(dataContract, documentType, data, identity)
+      const identityContractNonce = BigInt(1)
+
+      const tokenPaymentInfo = {
+        tokenContractId: '6hVQW16jyvZyGSQk2YVty4ND6bgFXozizYWnPt753uW5',
+        tokenContractPosition: 0,
+        minimumTokenCost: BigInt(1000),
+        maximumTokenCost: BigInt(100000),
+        gasFeesPaidBy: GasFeesPaidByWASM.ContractOwner
+      }
+
+      const stateTransition = sdk.documents.createStateTransition(document, 'create', { identityContractNonce, tokenPaymentInfo })
 
       expect(stateTransition).toEqual(expect.any(StateTransitionWASM))
     })

--- a/yarn.lock
+++ b/yarn.lock
@@ -5051,10 +5051,10 @@ prop-types@^15.8.1:
     object-assign "^4.1.1"
     react-is "^16.13.1"
 
-pshenmic-dpp@1.0.23-rc.2:
-  version "1.0.23-rc.2"
-  resolved "https://registry.yarnpkg.com/pshenmic-dpp/-/pshenmic-dpp-1.0.23-rc.2.tgz#a2b5d4dfa6ff66622c7fc7a1ae849847ae1fc087"
-  integrity sha512-beW3P94s6dfV8kBCY1XyG27gAjDD0HoEa6R4nKkYlyG+K141xMQw+sE4l81+eLksd6/MJwJsgBuF24DvbLf1gA==
+pshenmic-dpp@1.0.23-rc.3:
+  version "1.0.23-rc.3"
+  resolved "https://registry.yarnpkg.com/pshenmic-dpp/-/pshenmic-dpp-1.0.23-rc.3.tgz#a4cd6d9ed6c2d0e4e5b883b02d838a5e58af7062"
+  integrity sha512-mfQzoGRx3DifYKt37PHV72rFnztnOLOIeEzwNkJXgSWGZ+NDgKGYeS6YFQsHbXYKbAQse6iKQIOe+Rr3lhEVkA==
 
 punycode.js@^2.3.1:
   version "2.3.1"


### PR DESCRIPTION
# Issue

There is a Dash Platform protocol feature that let you charge tokens for a creation of document for specific document types, and it is defined in a data contract schema.

This PR adds an optional param tokenPaymentInfo in `createStateTransition` where you can specify neccesary tokens required by data contract schema and pay with token for your transaction

# Things done
* Added `tokenPaymentInfo` in params of `sdk.documents.createStateTransition`
* Added 1 unit test