### PR TITLE
Add contractBounds for IdentityPublicKeyInCreation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# dash-platform-sdk v1.2.0-rc.1
+# dash-platform-sdk v1.2.0
 [![GitHub license](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/pshenmic/dash-platform-sdk/blob/master/LICENSE) ![npm version](https://img.shields.io/npm/v/react.svg?style=flat) ![a](https://github.com/pshenmic/platform-explorer/actions/workflows/build.yml/badge.svg)
 
 

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "grpc-web": "^1.5.0",
     "hash.js": "^1.1.7",
     "nice-grpc-web": "^3.3.6",
-    "pshenmic-dpp": "1.0.23-rc.3",
+    "pshenmic-dpp": "1.0.23-rc.7",
     "rfc4648": "^1.5.4",
     "wasm-drive-verify": "github:owl352/wasm-drive-verify#9c572d86992d205d994cd7e0630a4bd14d284f8a"
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dash-platform-sdk",
-  "version": "1.1.9",
+  "version": "1.2.0",
   "main": "index.js",
   "description": "Lightweight SDK for accessing Dash Platform blockchain",
   "ts-standard": {

--- a/src/documents/createStateTransition.ts
+++ b/src/documents/createStateTransition.ts
@@ -61,7 +61,7 @@ export default function createStateTransition (document: DocumentWASM, type: 'cr
     throw new Error(`Document transition param "${missingArgument}" is missing`)
   }
 
-  const transitionParams = classArguments.map((classArgument: string) => params[classArgument])
+  const transitionParams = classArguments.concat(optionalArguments).map((classArgument: string) => params[classArgument])
 
   // @ts-expect-error
   const documentTransition = new TransitionClass(document, ...transitionParams).toDocumentTransition()

--- a/src/identities/index.ts
+++ b/src/identities/index.ts
@@ -7,12 +7,8 @@ import { IdentifierLike, IdentityTransitionParams } from '../types'
 import GRPCConnectionPool from '../grpcConnectionPool'
 import getIdentityByIdentifier from './getIdentityByIdentifier'
 import {
-  AssetLockProofWASM,
-  IdentifierWASM, IdentityPublicKeyInCreationWASM,
-  IdentityPublicKeyWASM,
-  IdentityWASM,
-  OutPointWASM,
-  StateTransitionWASM
+  AssetLockProofWASM, ContractBoundsWASM, IdentifierWASM, IdentityPublicKeyInCreationWASM,
+  IdentityPublicKeyWASM, IdentityWASM, OutPointWASM, StateTransitionWASM
 } from 'pshenmic-dpp'
 import createStateTransition from './createStateTransition'
 import getIdentityByNonUniquePublicKeyHash from './getIdentityByNonUniquePublicKeyHash'
@@ -152,12 +148,16 @@ export class IdentitiesController {
 
     if (params.addPublicKeys != null) {
       // @ts-expect-error
-      params.addPublicKeys = params.addPublicKeys.map(({ id, purpose, securityLevel, keyType, readOnly, data, signature }) => new IdentityPublicKeyInCreationWASM(id, purpose, securityLevel, keyType, readOnly, data, signature))
+      params.addPublicKeys = params.addPublicKeys
+        .map(({ id, purpose, securityLevel, keyType, readOnly, data, signature, contractBounds }) =>
+          new IdentityPublicKeyInCreationWASM(id, purpose, securityLevel, keyType, readOnly, data, signature, (contractBounds != null) ? new ContractBoundsWASM(contractBounds.dataContractId, contractBounds.documentType) : undefined))
     }
 
     if (params.publicKeys != null) {
       // @ts-expect-error
-      params.publicKeys = params.publicKeys.map(({ id, purpose, securityLevel, keyType, readOnly, data, signature }) => new IdentityPublicKeyInCreationWASM(id, purpose, securityLevel, keyType, readOnly, data, signature))
+      params.publicKeys = params.publicKeys
+        .map(({ id, purpose, securityLevel, keyType, readOnly, data, signature, contractBounds }) =>
+          new IdentityPublicKeyInCreationWASM(id, purpose, securityLevel, keyType, readOnly, data, signature, (contractBounds != null) ? new ContractBoundsWASM(contractBounds.dataContractId, contractBounds.documentType) : undefined))
     }
 
     return createStateTransition(type, params)

--- a/src/types.ts
+++ b/src/types.ts
@@ -213,6 +213,10 @@ export interface IdentityPublicKeyInCreation {
   readOnly: boolean
   data: Uint8Array
   signature?: Uint8Array
+  contractBounds?: {
+    dataContractId: IdentifierLike
+    documentType?: string
+  }
 }
 
 export interface IdentityTransitionParams {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5051,10 +5051,10 @@ prop-types@^15.8.1:
     object-assign "^4.1.1"
     react-is "^16.13.1"
 
-pshenmic-dpp@1.0.23-rc.3:
-  version "1.0.23-rc.3"
-  resolved "https://registry.yarnpkg.com/pshenmic-dpp/-/pshenmic-dpp-1.0.23-rc.3.tgz#a4cd6d9ed6c2d0e4e5b883b02d838a5e58af7062"
-  integrity sha512-mfQzoGRx3DifYKt37PHV72rFnztnOLOIeEzwNkJXgSWGZ+NDgKGYeS6YFQsHbXYKbAQse6iKQIOe+Rr3lhEVkA==
+pshenmic-dpp@1.0.23-rc.7:
+  version "1.0.23-rc.7"
+  resolved "https://registry.yarnpkg.com/pshenmic-dpp/-/pshenmic-dpp-1.0.23-rc.7.tgz#4a4d0025e69fc8fb78978b34be219e6c688d6691"
+  integrity sha512-I+cqkDgfCgi2rR6Yjn6QFRYvJtvCX+jtOQ5/ASDYnm3rkRjy6NK31lo7Np+AcOFpLIOjJyy3PoVU579UhQTCjg==
 
 punycode.js@^2.3.1:
   version "2.3.1"


### PR DESCRIPTION
# Issue

It is possible to specify the access level of the IdentityPublicKey, for example limit it to a certain DataContact or DataContact + DocumentTypeName.

There is a new pshenmic-dpp version that adds that support

# Things done

* Bumped pshenmic-dpp 
* Added optional field `contractBounds` in `IdentityPublicKeyInCreation`
* Fix TokenPaymentInfo for docment transitions