### PR TITLE
Fix transpiled source code not included in the build

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# dash-platform-sdk v1.3.0-dev.5
+# dash-platform-sdk v1.3.0-dev.6
 [![GitHub license](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/pshenmic/dash-platform-sdk/blob/master/LICENSE) ![npm version](https://img.shields.io/npm/v/react.svg?style=flat) ![a](https://github.com/pshenmic/platform-explorer/actions/workflows/build.yml/badge.svg)
 
 

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "typescript": "^5.8.2"
   },
   "scripts": {
-    "build": "rollup -c rollup.config.js",
+    "build": "tsc && rollup -c rollup.config.js",
     "build:grpc": "protoc -I=./proto --ts_opt generate_dependencies --ts_out=proto/generated --ts_opt=long_type_string ./proto/platform.proto",
     "build:typescript": "tsc",
     "lint": "ts-standard --fix",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dash-platform-sdk",
-  "version": "1.3.0-dev.5",
+  "version": "1.3.0-dev.6",
   "main": "index.js",
   "description": "Lightweight SDK for accessing Dash Platform blockchain",
   "ts-standard": {

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -18,7 +18,14 @@ export default [
       format: 'umd'
     },
     plugins: [
-      typescript({ module: 'ESNext' }),
+      typescript({
+        module: 'ESNext',
+        include: [
+          './proto/generated/**/*',
+          './index.ts',
+          './src/**/*'
+        ]
+      }),
       // babel(),
       resolve({
         'pshenmic-dpp': true

--- a/test/unit/DataContract.spec.ts
+++ b/test/unit/DataContract.spec.ts
@@ -10,7 +10,7 @@ let schema: object
 
 describe('DataContract', () => {
   beforeAll(() => {
-    sdk = new DashPlatformSDK({network: 'testnet'})
+    sdk = new DashPlatformSDK({ network: 'testnet' })
 
     ownerIdentifier = 'GARSAVFMjXx8HpQFaNJMqBV7MBgMK4br5UESsB4S31Ec'
     identityNonce = BigInt(11)

--- a/test/unit/Document.spec.ts
+++ b/test/unit/Document.spec.ts
@@ -10,7 +10,7 @@ let data: object
 
 describe('Document', () => {
   beforeAll(() => {
-    sdk = new DashPlatformSDK({network: 'testnet'})
+    sdk = new DashPlatformSDK({ network: 'testnet' })
     dataContract = '6QMfQTdKpC3Y9uWBcTwXeY3KdzRLDqASUsDnQ4MEc9XC'
     identity = 'QMfCRPcjXoTnZa9sA9JR2KWgGxZXMRJ4akgS3Uia1Qv'
     revision = BigInt(1)

--- a/test/unit/Identity.spec.ts
+++ b/test/unit/Identity.spec.ts
@@ -8,7 +8,7 @@ let sdk: DashPlatformSDK
 
 describe('Identity', () => {
   beforeAll(() => {
-    sdk = new DashPlatformSDK({network: 'testnet'})
+    sdk = new DashPlatformSDK({ network: 'testnet' })
   })
 
   test('should be able to get identity by identifier', async () => {

--- a/test/unit/Node.spec.ts
+++ b/test/unit/Node.spec.ts
@@ -4,7 +4,7 @@ let sdk: DashPlatformSDK
 
 describe('Node', () => {
   beforeAll(() => {
-    sdk = new DashPlatformSDK({network: 'testnet'})
+    sdk = new DashPlatformSDK({ network: 'testnet' })
   })
 
   test('should be able to call getStatus', async () => {

--- a/test/unit/SDK.spec.ts
+++ b/test/unit/SDK.spec.ts
@@ -4,7 +4,7 @@ let sdk: DashPlatformSDK
 
 describe('DashPlatformSDK', () => {
   beforeAll(() => {
-    sdk = new DashPlatformSDK({network: 'testnet'})
+    sdk = new DashPlatformSDK({ network: 'testnet' })
   })
 
   test('should be constructable throw `new`', () => {

--- a/test/unit/Tokens.spec.ts
+++ b/test/unit/Tokens.spec.ts
@@ -5,7 +5,7 @@ let sdk: DashPlatformSDK
 
 describe('Tokens', () => {
   beforeAll(() => {
-    sdk = new DashPlatformSDK({network: 'testnet'})
+    sdk = new DashPlatformSDK({ network: 'testnet' })
   })
 
   test('should be able to get token total supply', async () => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,12 +13,6 @@
   "include": [
     "./index.ts",
     "./src/**/*",
-    "./types/**/*",
-    "./test/**/*",
-    "./node_modules/@scure/bip32/node_modules/@scure/base/index.ts",
-    "./node_modules/@scure/bip39/node_modules/@scure/base/index.ts",
-    "./node_modules/micro-packed/node_modules/@scure/base/index.ts",
-    "./node_modules/@scure/btc-signer/node_modules/@scure/base/index.ts",
-    "./node_modules/@scure/bip32/index.ts"
+    "./test/**/*"
   ]
 }


### PR DESCRIPTION
# Issue

After a huge refactor in https://github.com/pshenmic/dash-platform-sdk/pull/38, there is .js source code is missing in the build. NPM build script was missing the `tsc` command and some more mistakes were found in the process of fixing.

Additionally, there was unnecessary node_modules being transpiled instead, which was not supposed to be there, also fixed.

# Things done
* Fixed lint in tests
* Removed @scure/* modules from tsconfig.json
* Added missing `tsc` command during build
* Fixed typescript rollup config 