### PR TITLE
`getContestedResourceVoteState` default value for `allowIncludeLockedAndAbstainingVoteTally` fix 

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dash-platform-sdk",
-  "version": "1.4.0-dev.6",
+  "version": "1.4.0-dev.7",
   "main": "index.js",
   "description": "Lightweight SDK for accessing Dash Platform blockchain",
   "ts-standard": {
@@ -55,6 +55,6 @@
     "@scure/bip39": "^2.0.0",
     "@scure/btc-signer": "^2.0.1",
     "cbor-x": "^1.6.0",
-    "pshenmic-dpp": "2.0.0-dev.9"
+    "pshenmic-dpp": "2.0.0-dev.10"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dash-platform-sdk",
-  "version": "1.4.0-dev.7",
+  "version": "1.4.0-dev.8",
   "main": "index.js",
   "description": "Lightweight SDK for accessing Dash Platform blockchain",
   "ts-standard": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5243,10 +5243,10 @@ protoc@^32.1.0:
   resolved "https://registry.npmjs.org/protoc/-/protoc-32.1.0.tgz"
   integrity sha512-yICJJCGHJLM9ao5W2V4CGp1d7xuBsdHzgVDw6L8mdDtoIcqzN3arNPOm9Jx4Ufp5vfhQfJGkNUDo6mm/SLPdXw==
 
-pshenmic-dpp@2.0.0-dev.9:
-  version "2.0.0-dev.9"
-  resolved "https://registry.yarnpkg.com/pshenmic-dpp/-/pshenmic-dpp-2.0.0-dev.9.tgz#11908a3d8f4f8ee906a0705de3af1062e3dd7f1f"
-  integrity sha512-OahGS1OmAcK5EMEq8P5S8tqBqAd/R7QCB5PWQB/7EiF1RMmCd7pV++zjzuPB9w4zjf7AL7Urpj3gzMO0JpwsNA==
+pshenmic-dpp@2.0.0-dev.10:
+  version "2.0.0-dev.10"
+  resolved "https://registry.yarnpkg.com/pshenmic-dpp/-/pshenmic-dpp-2.0.0-dev.10.tgz#bef1a0fb1ff143fe24f54bdb8dbf66348c8e64aa"
+  integrity sha512-NQZqI0WKSjXHA9Z/1SFpI6HqdIlGRxEYbuC+JkmPcUe1RWmQqASay7T4LX0NvbV8aOae2vKS7ELzYqTZCk3XSg==
   dependencies:
     "@emnapi/core" "1.9.0"
     "@emnapi/runtime" "1.9.0"


### PR DESCRIPTION
# Issue
At this moment we have error on platform explorer when trying to get contested resourve vote state when he on vote

# Things done
- Changed default value for flag `allowIncludeLockedAndAbstainingVoteTally` in pshenmic-dpp
- Bump versions