### PR TITLE
Add native libraries support for Node.js Env

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,6 +55,6 @@
     "@scure/bip39": "^2.0.0",
     "@scure/btc-signer": "^2.0.1",
     "cbor-x": "^1.6.0",
-    "pshenmic-dpp": "2.0.0-dev.15"
+    "pshenmic-dpp": "2.0.0-dev.16"
   }
 }

--- a/package.json
+++ b/package.json
@@ -55,6 +55,6 @@
     "@scure/bip39": "^2.0.0",
     "@scure/btc-signer": "^2.0.1",
     "cbor-x": "^1.6.0",
-    "pshenmic-dpp": "2.0.0-dev.10"
+    "pshenmic-dpp": "2.0.0-dev.14"
   }
 }

--- a/package.json
+++ b/package.json
@@ -55,6 +55,6 @@
     "@scure/bip39": "^2.0.0",
     "@scure/btc-signer": "^2.0.1",
     "cbor-x": "^1.6.0",
-    "pshenmic-dpp": "2.0.0-dev.14"
+    "pshenmic-dpp": "2.0.0-dev.15"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dash-platform-sdk",
-  "version": "1.4.0-dev.7",
+  "version": "1.4.0-dev.8",
   "main": "index.js",
   "description": "Lightweight SDK for accessing Dash Platform blockchain",
   "ts-standard": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5243,10 +5243,10 @@ protoc@^32.1.0:
   resolved "https://registry.npmjs.org/protoc/-/protoc-32.1.0.tgz"
   integrity sha512-yICJJCGHJLM9ao5W2V4CGp1d7xuBsdHzgVDw6L8mdDtoIcqzN3arNPOm9Jx4Ufp5vfhQfJGkNUDo6mm/SLPdXw==
 
-pshenmic-dpp@2.0.0-dev.10:
-  version "2.0.0-dev.10"
-  resolved "https://registry.yarnpkg.com/pshenmic-dpp/-/pshenmic-dpp-2.0.0-dev.10.tgz#bef1a0fb1ff143fe24f54bdb8dbf66348c8e64aa"
-  integrity sha512-NQZqI0WKSjXHA9Z/1SFpI6HqdIlGRxEYbuC+JkmPcUe1RWmQqASay7T4LX0NvbV8aOae2vKS7ELzYqTZCk3XSg==
+pshenmic-dpp@2.0.0-dev.14:
+  version "2.0.0-dev.14"
+  resolved "https://registry.yarnpkg.com/pshenmic-dpp/-/pshenmic-dpp-2.0.0-dev.14.tgz#a229280f9b4241c257ff9568a06120dd5010a025"
+  integrity sha512-tmpIFbVoxQki7ohgJGlzVtmGU4sKzpVcGUmYJ/OJso/dLp2SWYGqnlBwtl8+RETUE+q9jYUhs0vrLRk8TGMNNQ==
   dependencies:
     "@emnapi/core" "1.9.0"
     "@emnapi/runtime" "1.9.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5243,10 +5243,10 @@ protoc@^32.1.0:
   resolved "https://registry.npmjs.org/protoc/-/protoc-32.1.0.tgz"
   integrity sha512-yICJJCGHJLM9ao5W2V4CGp1d7xuBsdHzgVDw6L8mdDtoIcqzN3arNPOm9Jx4Ufp5vfhQfJGkNUDo6mm/SLPdXw==
 
-pshenmic-dpp@2.0.0-dev.15:
-  version "2.0.0-dev.15"
-  resolved "https://registry.yarnpkg.com/pshenmic-dpp/-/pshenmic-dpp-2.0.0-dev.15.tgz#b68c647ec8de6af1c15e25d07db32db46c0ca9af"
-  integrity sha512-dKiYoVs+2jZEp0iTwUCXAjPAiVPtEmEsmESgkA3/I/7S8vNW1qG5uwsPfNLkglnDulM1QwUU0N8M7xVWLaW5cg==
+pshenmic-dpp@2.0.0-dev.16:
+  version "2.0.0-dev.16"
+  resolved "https://registry.yarnpkg.com/pshenmic-dpp/-/pshenmic-dpp-2.0.0-dev.16.tgz#c1e58554c02cd764377e80cf464ba82a6fae483b"
+  integrity sha512-oCqdMUAsYNj23RiG2xC7Mz60kdnVWlyUlJ42NvhTPEeTmlotB/OCLsKpBLubGC/B6ge6z26kH66Ae4ShW/NniQ==
   dependencies:
     "@emnapi/core" "1.9.0"
     "@emnapi/runtime" "1.9.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5243,10 +5243,10 @@ protoc@^32.1.0:
   resolved "https://registry.npmjs.org/protoc/-/protoc-32.1.0.tgz"
   integrity sha512-yICJJCGHJLM9ao5W2V4CGp1d7xuBsdHzgVDw6L8mdDtoIcqzN3arNPOm9Jx4Ufp5vfhQfJGkNUDo6mm/SLPdXw==
 
-pshenmic-dpp@2.0.0-dev.14:
-  version "2.0.0-dev.14"
-  resolved "https://registry.yarnpkg.com/pshenmic-dpp/-/pshenmic-dpp-2.0.0-dev.14.tgz#a229280f9b4241c257ff9568a06120dd5010a025"
-  integrity sha512-tmpIFbVoxQki7ohgJGlzVtmGU4sKzpVcGUmYJ/OJso/dLp2SWYGqnlBwtl8+RETUE+q9jYUhs0vrLRk8TGMNNQ==
+pshenmic-dpp@2.0.0-dev.15:
+  version "2.0.0-dev.15"
+  resolved "https://registry.yarnpkg.com/pshenmic-dpp/-/pshenmic-dpp-2.0.0-dev.15.tgz#b68c647ec8de6af1c15e25d07db32db46c0ca9af"
+  integrity sha512-dKiYoVs+2jZEp0iTwUCXAjPAiVPtEmEsmESgkA3/I/7S8vNW1qG5uwsPfNLkglnDulM1QwUU0N8M7xVWLaW5cg==
   dependencies:
     "@emnapi/core" "1.9.0"
     "@emnapi/runtime" "1.9.0"


### PR DESCRIPTION
# Issue
napi-rs allows to build binaries for any platforms and run as dynamic library

# Things done
- Updated dpp for build and import binaries in supported platforms
- Bump dpp version in `package.json`
- Bump package version