### PR TITLE
Extend pshenmic-dpp memory arena

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "docs": "typedoc"
   },
   "peerDependencies": {
-    "pshenmic-dpp": "1.1.2-dev.8"
+    "pshenmic-dpp": "1.1.2-dev.9"
   },
   "dependencies": {
     "@bufbuild/protobuf": "^2.6.0",
@@ -59,6 +59,6 @@
     "@scure/bip39": "^2.0.0",
     "@scure/btc-signer": "^2.0.1",
     "cbor-x": "^1.6.0",
-    "pshenmic-dpp": "1.1.2-dev.8"
+    "pshenmic-dpp": "1.1.2-dev.9"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dash-platform-sdk",
-  "version": "1.3.1",
+  "version": "1.3.2-dev.1",
   "main": "index.js",
   "description": "Lightweight SDK for accessing Dash Platform blockchain",
   "ts-standard": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5214,10 +5214,10 @@ protoc@^32.1.0:
   resolved "https://registry.npmjs.org/protoc/-/protoc-32.1.0.tgz"
   integrity sha512-yICJJCGHJLM9ao5W2V4CGp1d7xuBsdHzgVDw6L8mdDtoIcqzN3arNPOm9Jx4Ufp5vfhQfJGkNUDo6mm/SLPdXw==
 
-pshenmic-dpp@1.1.2-dev.8:
-  version "1.1.2-dev.8"
-  resolved "https://registry.yarnpkg.com/pshenmic-dpp/-/pshenmic-dpp-1.1.2-dev.8.tgz#ecb15836c6ec9cbc994d7535f360e020f10e2e04"
-  integrity sha512-P3czQ6uJYHr7XJ2OSWUH+FNej7Qpa+bz8Ld7+FtUqjGCBpwK6GTGQy1PDmACT9nP8+DXpFTUGu7Au9u66kvcdA==
+pshenmic-dpp@1.1.2-dev.9:
+  version "1.1.2-dev.9"
+  resolved "https://registry.yarnpkg.com/pshenmic-dpp/-/pshenmic-dpp-1.1.2-dev.9.tgz#526b040b5bf1fcc71291cdeebda772f4bde1221d"
+  integrity sha512-ilX2/gld20UXPn2DORt4V68nynehv2z0lTn+aQRc6/sGhZQOOs0mJGX1WsrHlV+TSFxbIfBTU/YwJubr2cEjbQ==
   dependencies:
     fflate "^0.8.2"
 


### PR DESCRIPTION
# Issue
In some scenarios we get `memory access out of bounds` from pshenmic-dpp

# Things done
- Bumped `pshenmic-dpp` to `1.3.0-dev.9` with increased memory arena size (100mb -> 130mb)
- Bumped package version