### PR TITLE
Fix ternary for `wonByIdentityId` in `getContestedResourceVoteState()`

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dash-platform-sdk",
-  "version": "1.4.0-dev.8",
+  "version": "1.4.0-dev.9",
   "main": "index.js",
   "description": "Lightweight SDK for accessing Dash Platform blockchain",
   "ts-standard": {

--- a/src/contestedResources/getContestedResourceVoteState.ts
+++ b/src/contestedResources/getContestedResourceVoteState.ts
@@ -116,7 +116,7 @@ export default async function getContestedResourceVoteState (
     finishedVoteInfo: (winner != null)
       ? {
           type: winner.type,
-          wonByIdentityId: winner.identityId != null ? new IdentifierWASM(winner.identityId) : undefined,
+          wonByIdentityId: 'identityId' in winner && winner.identityId != null ? new IdentifierWASM(winner.identityId) : undefined,
           finishedAtBlockHeight: winner.blockInfo.height,
           finishedAtCoreBlockHeight: winner.blockInfo.coreHeight,
           finishedAtBlockTimeMs: winner.blockInfo.timeMs,

--- a/src/contestedResources/getContestedResourceVoteState.ts
+++ b/src/contestedResources/getContestedResourceVoteState.ts
@@ -116,7 +116,7 @@ export default async function getContestedResourceVoteState (
     finishedVoteInfo: (winner != null)
       ? {
           type: winner.type,
-          wonByIdentityId: 'identityId' in winner ? new IdentifierWASM(winner.identityId) : undefined,
+          wonByIdentityId: winner.identityId != null ? new IdentifierWASM(winner.identityId) : undefined,
           finishedAtBlockHeight: winner.blockInfo.height,
           finishedAtCoreBlockHeight: winner.blockInfo.coreHeight,
           finishedAtBlockTimeMs: winner.blockInfo.timeMs,


### PR DESCRIPTION
# Issue
At this moment we throw error if we get null `wonByIdentityId` in `getContestedResourceVoteState`

# Things done
- Replaced condition in ternary for `wonByIdentityId`
- Bump package version