### PR TITLE
Feat/fix docs query

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dash-platform-sdk",
-  "version": "1.4.0-dev.9",
+  "version": "1.4.0-dev.10",
   "main": "index.js",
   "description": "Lightweight SDK for accessing Dash Platform blockchain",
   "ts-standard": {

--- a/src/documents/index.ts
+++ b/src/documents/index.ts
@@ -51,7 +51,7 @@ export class DocumentsController {
    * @param startAfter {IdentifierLike=} Same as previous, but with exclusion. Cannot be set if startAt already provided
    */
   async query (dataContractId: IdentifierLike, documentType: string, where?: WhereClause[], orderBy?: string[][], limit?: number, startAt?: IdentifierWASM, startAfter?: IdentifierWASM): Promise<DocumentWASM[]> {
-    if (startAfter != null && startAt !== null) {
+    if (startAfter != null && startAt != null) {
       throw new Error('You may only set either startAfter or startAt at once')
     }
 

--- a/src/documents/query.ts
+++ b/src/documents/query.ts
@@ -18,10 +18,6 @@ export default async function query (
   startAt?: IdentifierWASM,
   startAfter?: IdentifierWASM
 ): Promise<DocumentWASM[]> {
-  if ([startAt, startAfter].filter(e => e != null).length === 2) {
-    throw new Error('Only startAt or startAfter could be specified at one time')
-  }
-
   let start
 
   if (startAt != null) {


### PR DESCRIPTION
# Issue
At this moment we have incorrect value validation in `query` method for `DocumentsController`. 
In top of method we checks that user doesn't pass `startAt` and `startTime` in one time via `!= null`, but for `startAt` we have `!== null` which means if we pass undefined for `startAt` - we get error

# Things done
- Fixed `!==`
- Removed double check for one time `startAt` and `startAfter` passing
- Bump package version