### PR TITLE
Fix incorrect `startAt` and `startAfter` types in documents query

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dash-platform-sdk",
-  "version": "1.4.0-dev.10",
+  "version": "1.4.0-dev.11",
   "main": "index.js",
   "description": "Lightweight SDK for accessing Dash Platform blockchain",
   "ts-standard": {

--- a/src/documents/query.ts
+++ b/src/documents/query.ts
@@ -23,14 +23,14 @@ export default async function query (
   if (startAt != null) {
     start = {
       oneofKind: 'startAt',
-      startAt: startAt.base58()
+      startAt: startAt.bytes()
     }
   }
 
   if (startAfter != null) {
     start = {
       oneofKind: 'startAfter',
-      startAt: startAfter.base58()
+      startAfter: startAfter.bytes()
     }
   }
 
@@ -73,11 +73,12 @@ export default async function query (
   }
 
   const startAtIncluded = startAt != null
+  const startIdentifier = startAt ?? startAfter
 
   const {
     rootHash,
     documents
-  } = verifyDocumentsProof(proof.grovedbProof, dataContract, documentTypeName, where, orderBy, limit, startAt?.bytes(), startAtIncluded, BigInt(metadata?.timeMs), LATEST_PLATFORM_VERSION)
+  } = verifyDocumentsProof(proof.grovedbProof, dataContract, documentTypeName, where, orderBy, limit, startIdentifier?.bytes(), startAtIncluded, BigInt(metadata?.timeMs), LATEST_PLATFORM_VERSION)
   const quorumPublicKey = await getQuorumPublicKey(grpcPool.network, proof.quorumType, bytesToHex(proof.quorumHash))
 
   const verify = await verifyTenderdashProof(proof, metadata, rootHash, quorumPublicKey)

--- a/test/unit/Document.spec.ts
+++ b/test/unit/Document.spec.ts
@@ -55,6 +55,46 @@ describe('Document', () => {
     expect(document).toEqual(expect.any(DocumentWASM))
   })
 
+  test('should be able to get document with startAt', async () => {
+    const dataContract = '6hVQW16jyvZyGSQk2YVty4ND6bgFXozizYWnPt753uW5'
+    const documentType = 'torrent'
+    const limit = 5
+
+    // @ts-expect-error
+    const [firstQueriedDoc] = (await sdk.documents.query(dataContract, documentType, null, null, limit)).toReversed()
+    // @ts-expect-error
+    const [secondQueriedDoc] = await sdk.documents.query(dataContract, documentType, null, null, limit, firstQueriedDoc.id)
+
+    expect(secondQueriedDoc.id.base58()).toEqual(firstQueriedDoc.id.base58())
+
+    expect(secondQueriedDoc.createdAtBlockHeight).toEqual(undefined)
+
+    expect(secondQueriedDoc.dataContractId.base58()).toEqual(dataContract)
+    expect(secondQueriedDoc).toEqual(expect.any(DocumentWASM))
+  })
+
+  test('should be able to get document with startAfter', async () => {
+    const dataContract = '6hVQW16jyvZyGSQk2YVty4ND6bgFXozizYWnPt753uW5'
+    const documentType = 'torrent'
+    const limit = 5
+    const masterQueryLimit = limit*2
+
+    // @ts-expect-error
+    const masterQuery = await sdk.documents.query(dataContract, documentType, null, null, masterQueryLimit)
+
+    // @ts-expect-error
+    const [firstQueriedDoc] = (await sdk.documents.query(dataContract, documentType, null, null, limit)).toReversed()
+    // @ts-expect-error
+    const [secondQueriedDoc] = await sdk.documents.query(dataContract, documentType, null, null, limit, undefined, firstQueriedDoc.id)
+
+    expect(masterQuery[5].id.base58()).toEqual(secondQueriedDoc.id.base58())
+
+    expect(secondQueriedDoc.createdAtBlockHeight).toEqual(undefined)
+
+    expect(secondQueriedDoc.dataContractId.base58()).toEqual(dataContract)
+    expect(secondQueriedDoc).toEqual(expect.any(DocumentWASM))
+  })
+
   describe('should be able to create state transition', () => {
     test('should be able to create a create transition', async () => {
       const document = sdk.documents.create(dataContract, documentType, data, identity)


### PR DESCRIPTION
# Issue
At this moment we trying to pass as `startAt` and `startAfter` base58 string, but it must be bytes.
Also at this moment we call verify method incorrect for queries with `startAt` and `startAfter`

# Things done
- Fixed types for `startAt` and `startAfter`
- Updated verify call
- Implemented test
- Bump package version