### PR TITLE
Fix incorrect deserialization token configuration on rust side

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dash-platform-sdk",
-  "version": "1.4.0-dev.12",
+  "version": "1.4.0-dev.13",
   "main": "index.js",
   "description": "Lightweight SDK for accessing Dash Platform blockchain",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -59,6 +59,6 @@
     "@scure/bip39": "^2.0.0",
     "@scure/btc-signer": "^2.0.1",
     "cbor-x": "^1.6.0",
-    "pshenmic-dpp": "2.0.0-dev.17"
+    "pshenmic-dpp": "2.0.0-dev.18"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5243,10 +5243,10 @@ protoc@^32.1.0:
   resolved "https://registry.npmjs.org/protoc/-/protoc-32.1.0.tgz"
   integrity sha512-yICJJCGHJLM9ao5W2V4CGp1d7xuBsdHzgVDw6L8mdDtoIcqzN3arNPOm9Jx4Ufp5vfhQfJGkNUDo6mm/SLPdXw==
 
-pshenmic-dpp@2.0.0-dev.17:
-  version "2.0.0-dev.17"
-  resolved "https://registry.yarnpkg.com/pshenmic-dpp/-/pshenmic-dpp-2.0.0-dev.17.tgz#bd385319724270f28915ebb30793597ee7e35ee8"
-  integrity sha512-zRweXH/+lZTbc2xy7R0qnLwMniE3yJihndGgHH3qWFhsUf88iQIKRwNm1DM0cdgiHf0gLVptaCr4BWKw+YsJ0w==
+pshenmic-dpp@2.0.0-dev.18:
+  version "2.0.0-dev.18"
+  resolved "https://registry.yarnpkg.com/pshenmic-dpp/-/pshenmic-dpp-2.0.0-dev.18.tgz#3bd59871c823c4055a08c936d0534deb9eec70d3"
+  integrity sha512-YwXdQarhJr7USCn1lC80TQongr2mmlr3MObukFPUr9b0/yYDAzLD3AZXzbhM8KhgT+uyJVrqT/bRAbXN0gUOGA==
   dependencies:
     "@emnapi/core" "1.9.0"
     "@emnapi/runtime" "1.9.0"


### PR DESCRIPTION
# Issue
Currently in dpp token configuration sets via `platform_value` in data contract constructor, but `Identifier` as `TokenDistributionRecipient` throw error because on serialization to `platform_value`, `Identifier` will be serialized as bytes, but for data contract it must be base58 string

# Things done
- Fixed in [new psehnmic-dpp release](https://github.com/owl352/pshenmic-dpp/releases/tag/2.0.0-dev.18)
- Bump dpp version
- Bump package version