### PR TITLE
Update old protocol naming

### DIFF
--- a/docs/examples/DataContracts.md
+++ b/docs/examples/DataContracts.md
@@ -33,7 +33,7 @@ const schema = {
 }
 
 const config = {
-  $format_version: '0',
+  $formatVersion: '0',
   canBeDeleted: true,
   readonly: false,
   keepsHistory: false,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dash-platform-sdk",
-  "version": "1.4.0-dev.14",
+  "version": "1.4.0-dev.15",
   "main": "index.js",
   "description": "Lightweight SDK for accessing Dash Platform blockchain",
   "repository": {

--- a/test/unit/DataContract.spec.ts
+++ b/test/unit/DataContract.spec.ts
@@ -16,7 +16,7 @@ describe('DataContract', () => {
     identityNonce = BigInt(11)
 
     config = {
-      $format_version: '1',
+      $formatVersion: '1',
       canBeDeleted: true,
       readonly: true,
       keepsHistory: false,

--- a/test/unit/PlatformAddress.spec.ts
+++ b/test/unit/PlatformAddress.spec.ts
@@ -8,7 +8,7 @@ describe('PlatformAddress', () => {
   })
 
   test('getAddressInfo', async () => {
-    const info = await sdk.platformAddresses.getAddressInfo('tdashevo1qpgz9hk6tkn5zj3653s8qkjmk9439qkf0gl4yxxw')
+    const info = await sdk.platformAddresses.getAddressInfo('tdash1kzg5azscav69z7m6dfzr9ner0a5vt7pn9ca4sz8d')
 
     expect(info.balance).toBeDefined()
     expect(info.nonce).toBeDefined()
@@ -17,9 +17,9 @@ describe('PlatformAddress', () => {
 
   test('getAddressesInfos', async () => {
     const addresses = [
-      'tdashevo1qpgz9hk6tkn5zj3653s8qkjmk9439qkf0gl4yxxw',
-      'tdashevo1qq79z66rh34l4u2axlz3jv34zwshggnenut9k093',
-      'tdashevo1qpwyg4khd0rh8px5cjphv9wx38psl6hma5krg9gk'
+      'tdash1kzg5azscav69z7m6dfzr9ner0a5vt7pn9ca4sz8d',
+      'tdash1kqr3cxhgel75ru0yrhj5eq8j8jt92m5enqrfajxw',
+      'tdash1kq9plfyacx9q26dtaxgwuw9lt78nyu2mzc3xwcxv'
     ]
     const info = await sdk.platformAddresses.getAddressesInfos(addresses)
 

--- a/types.ts
+++ b/types.ts
@@ -171,7 +171,7 @@ export interface ContestedResourceVoteState {
 }
 
 export interface DataContractConfig {
-  $format_version: string
+  $formatVersion: string
   canBeDeleted: boolean
   readonly: boolean
   keepsHistory: boolean


### PR DESCRIPTION
# Issue
After update to platform v4 `$format_version` in data-contract was replaced by `$formatVersion` and also was changed platform addresses prefix for testnet

# Things done
- replaced `$format_version` by `$formatVersion`
- updated tests for platform addresses (changed prefix)
- bump package version