### PR TITLE
Export const enum

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dash-platform-sdk",
-  "version": "1.4.0-dev.15",
+  "version": "1.4.0-dev.16",
   "main": "index.js",
   "description": "Lightweight SDK for accessing Dash Platform blockchain",
   "repository": {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,8 @@
     "moduleResolution": "NodeNext",
     "declaration": true,
     "strictNullChecks": true,
-    "emitDeclarationOnly": false
+    "emitDeclarationOnly": false,
+    "preserveConstEnums": true
   },
   "include": [
     "./index.ts",


### PR DESCRIPTION
# Issue
new version of `pshenmic-dpp` contains const enums, but in sdk `tsconfig.json` currently disabled `preserveConstEnums` and that means that export of enums like `Purpose` exist only in `*d.ts` files, but not `*.js`

# Things done
- enable `preserveConstEnums`
- bump package version 