### PR TITLE
Replace `const enum` with `enum`

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dash-platform-sdk",
-  "version": "1.4.0-dev.16",
+  "version": "1.4.0-dev.17",
   "main": "index.js",
   "description": "Lightweight SDK for accessing Dash Platform blockchain",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -59,6 +59,6 @@
     "@scure/bip39": "^2.0.0",
     "@scure/btc-signer": "^2.0.1",
     "cbor-x": "^1.6.0",
-    "pshenmic-dpp": "2.0.0-dev.19"
+    "pshenmic-dpp": "2.0.0-dev.20"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5243,10 +5243,10 @@ protoc@^32.1.0:
   resolved "https://registry.npmjs.org/protoc/-/protoc-32.1.0.tgz"
   integrity sha512-yICJJCGHJLM9ao5W2V4CGp1d7xuBsdHzgVDw6L8mdDtoIcqzN3arNPOm9Jx4Ufp5vfhQfJGkNUDo6mm/SLPdXw==
 
-pshenmic-dpp@2.0.0-dev.19:
-  version "2.0.0-dev.19"
-  resolved "https://registry.yarnpkg.com/pshenmic-dpp/-/pshenmic-dpp-2.0.0-dev.19.tgz#e2c12852afb759f4f0df277f46bf63bd32b82422"
-  integrity sha512-ifLHaj/n2m9pmnPAuTXqpzqZeY/OWWm7yso2qFbm1hni3I3jerpZ2ogYutTXeqvLQgW8+czUb6/af5RMADos6g==
+pshenmic-dpp@2.0.0-dev.20:
+  version "2.0.0-dev.20"
+  resolved "https://registry.yarnpkg.com/pshenmic-dpp/-/pshenmic-dpp-2.0.0-dev.20.tgz#45b30ae6b214630ce7bd518d274506b6cc29b4a0"
+  integrity sha512-ZjytCJvdiUPyGX4PhBreGHXxKgzJR/FkG6F0FrUBCptb5ixqPscm+zsRHsB7bFEf+yfBoMr2NMEKI+LTZ5h9sg==
   dependencies:
     "@emnapi/core" "1.9.0"
     "@emnapi/runtime" "1.9.0"


### PR DESCRIPTION
# Issue
Currently dpp exports `const enum` which doesn't allow to get value by key from variable

# Things done
- Update dpp to [new version with fix](https://github.com/owl352/pshenmic-dpp/pull/186)
- Bump package version