### PR TITLE
feat: add createStateTransition builder for Platform Address transitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,5 +116,6 @@ The folder `docs/examples` in this repo contains useful example code snippets.
 | [Utils.md](docs/examples/Utils.md) | useful utility functions, like hex/base58 encoding, createVoterIdentifier, createMasternodeIdentifier, validateIdentifier                                                                                           |
 | [KeyPair.md](docs/examples/KeyPair.md) | Mnemonic to Seed, Seed to HD Key, Derive Identity Private Key, Derive Child, Derive Path, P2PKH Address conversion                                                                                                  |
 | [ContestedResources.md](docs/examples/ContestedResources.md) | Contested Resource Vote State Info                                                                                                                                                                                  |
+| [PlatformAddresses.md](docs/examples/PlatformAddresses.md) | Get Address Info, Create State Transition, Convenience builders (Transfer To Address, Create / Top Up Identity From Addresses, Transfer Between Addresses, Fund From Asset Lock, Withdrawal To Core)                |
 
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# dash-platform-sdk v1.4.0-dev.4
+# dash-platform-sdk v1.4.1-dev.1
 [![GitHub license](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/pshenmic/dash-platform-sdk/blob/master/LICENSE) ![npm version](https://img.shields.io/npm/v/react.svg?style=flat) ![a](https://github.com/pshenmic/platform-explorer/actions/workflows/build.yml/badge.svg)
 
 

--- a/docs/examples/PlatformAddresses.md
+++ b/docs/examples/PlatformAddresses.md
@@ -1,0 +1,186 @@
+# Platform Addresses
+
+Platform addresses hold credits directly on Platform (without an Identity). The SDK exposes read
+queries for address balance/nonce, a low-level `createStateTransition` builder for all six Platform
+Address transitions, and convenience builders on top of it.
+
+> **Signing.** Address-funded transitions carry their signature material as constructor input via
+> `inputWitness: AddressWitnessWASM[]`. Witnesses are produced by the client application (wallet,
+> mobile app or browser extension) where the address private keys live - the SDK builders never sign
+> and never hit the network. Build the witnesses with `AddressWitnessWASM.P2PKH(signature)` /
+> `AddressWitnessWASM.P2SH(signatures, redeemScript)` and pass them in.
+
+## Get Address Info
+
+Returns an object with `address`, `balance` and `nonce` for a Platform address.
+
+```javascript
+const info = await sdk.platformAddresses.getAddressInfo('tdash1kzg5azscav69z7m6dfzr9ner0a5vt7pn9ca4sz8d')
+
+console.log(info.balance, info.nonce)
+```
+
+## Get Addresses Infos
+
+Same as above for a batch of addresses.
+
+```javascript
+const infos = await sdk.platformAddresses.getAddressesInfos([
+  'tdash1kzg5azscav69z7m6dfzr9ner0a5vt7pn9ca4sz8d',
+  'tdash1kqr3cxhgel75ru0yrhj5eq8j8jt92m5enqrfajxw'
+])
+
+console.log(infos)
+```
+
+## Building the params
+
+The entity classes used below are re-exported from the SDK, so you don't need to import
+`pshenmic-dpp` directly:
+
+```javascript
+import {
+  InputAddressWASM,
+  OutputAddressWASM,
+  OutputAddressNullableCreditsWASM,
+  AddressFundsFeeStrategyStepWASM,
+  AddressWitnessWASM
+} from 'dash-platform-sdk'
+
+const sender = 'tdash1kzg5azscav69z7m6dfzr9ner0a5vt7pn9ca4sz8d'
+const recipient = 'tdash1kqr3cxhgel75ru0yrhj5eq8j8jt92m5enqrfajxw'
+
+// inputs spent from Platform addresses (nonce from getAddressInfo)
+const inputs = [new InputAddressWASM(sender, 0, 100000n)]
+// where the credits go
+const outputs = [new OutputAddressWASM(recipient, 50000n)]
+// how fees are deducted
+const feeStrategy = [AddressFundsFeeStrategyStepWASM.DeductFromInput(1)]
+// signatures over the inputs, produced by the client app holding the keys
+const inputWitness = [AddressWitnessWASM.P2PKH(signature)]
+```
+
+## Convenience builders
+
+### Transfer To Address (Identity → addresses)
+
+Transfer credits from an Identity to one or more Platform addresses. Signed by the Identity key
+after construction, so no `inputWitness` is required.
+
+```javascript
+const identityId = 'QMfCRPcjXoTnZa9sA9JR2KWgGxZXMRJ4akgS3Uia1Qv'
+const nonce = await sdk.identities.getIdentityNonce(identityId)
+
+const stateTransition = sdk.platformAddresses.transferToAddress({
+  identityId,
+  recipient,
+  amount: 50000n,
+  nonce
+})
+
+stateTransition.sign(privateKey, identityPublicKey)
+
+await sdk.stateTransitions.broadcast(stateTransition)
+await sdk.stateTransitions.waitForStateTransitionResult(stateTransition)
+```
+
+### Create Identity From Addresses
+
+Create a new Identity funded from Platform addresses.
+
+```javascript
+const stateTransition = sdk.platformAddresses.createIdentityFromAddresses({
+  publicKeys,
+  inputs,
+  feeStrategy,
+  inputWitness
+})
+
+await sdk.stateTransitions.broadcast(stateTransition)
+```
+
+### Top Up Identity From Addresses
+
+Top up an existing Identity from Platform addresses.
+
+```javascript
+const stateTransition = sdk.platformAddresses.topUpFromAddresses({
+  identityId: 'QMfCRPcjXoTnZa9sA9JR2KWgGxZXMRJ4akgS3Uia1Qv',
+  inputs,
+  feeStrategy,
+  inputWitness
+})
+
+await sdk.stateTransitions.broadcast(stateTransition)
+```
+
+### Transfer Between Addresses
+
+Transfer credits from one set of Platform addresses to another.
+
+```javascript
+const stateTransition = sdk.platformAddresses.transferBetweenAddresses({
+  inputs,
+  feeStrategy,
+  inputWitness,
+  outputs
+})
+
+await sdk.stateTransitions.broadcast(stateTransition)
+```
+
+### Fund From Asset Lock
+
+Fund Platform addresses from a Core asset lock proof. The recipient outputs may omit credits
+(`OutputAddressNullableCreditsWASM`).
+
+```javascript
+const outputs = [new OutputAddressNullableCreditsWASM(recipient)]
+
+const stateTransition = sdk.platformAddresses.fundFromAssetLock({
+  assetLockProof,
+  inputs,
+  feeStrategy,
+  inputWitness,
+  outputs
+})
+
+await sdk.stateTransitions.broadcast(stateTransition)
+```
+
+### Withdrawal To Core
+
+Withdraw from Platform addresses to a Core (L1) address. Pass a `coreAddress` (converted to a P2PKH
+output script for you) or an explicit `outputScript`. `coreFeePerByte` defaults to `1` and `pooling`
+to `'Standard'`.
+
+```javascript
+const stateTransition = sdk.platformAddresses.withdrawalToCore({
+  inputs,
+  feeStrategy,
+  inputWitness,
+  coreAddress: 'yjHVQ3dj37UJwXFmvMTKR9ZVfoJSc3opTD'
+})
+
+await sdk.stateTransitions.broadcast(stateTransition)
+```
+
+## Low-level: Create State Transition
+
+`createStateTransition(type, params)` is the low-level builder the convenience methods delegate to.
+`type` is one of `identityCreditTransferToAddresses`, `identityCreateFromAddresses`,
+`identityTopUpFromAddresses`, `addressFundsTransfer`, `addressFundingFromAssetLock`,
+`addressCreditWithdrawal`. Pass the constructor params directly (already-built entities):
+
+```javascript
+const stateTransition = sdk.platformAddresses.createStateTransition('addressFundsTransfer', {
+  inputs,
+  feeStrategy,
+  inputWitness,
+  outputs
+})
+
+await sdk.stateTransitions.broadcast(stateTransition)
+```
+
+More detailed usage can be seen in `test/unit/PlatformAddress.spec.ts`.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dash-platform-sdk",
-  "version": "1.4.0-dev.17",
+  "version": "1.4.1-dev.1",
   "main": "index.js",
   "description": "Lightweight SDK for accessing Dash Platform blockchain",
   "repository": {

--- a/src/platformAddresses/createStateTransition.ts
+++ b/src/platformAddresses/createStateTransition.ts
@@ -1,0 +1,86 @@
+import {
+  IdentityCreditTransferToAddressesTransitionWASM,
+  IdentityCreateFromAddressesTransitionWASM,
+  IdentityTopUpFromAddressesTransitionWASM,
+  AddressFundsTransferTransitionWASM,
+  AddressFundingFromAssetLockTransitionWASM,
+  AddressCreditWithdrawalTransitionWASM,
+  StateTransitionWASM
+} from 'pshenmic-dpp'
+import { PlatformAddressTransitionParams } from '../../types.js'
+
+export type PlatformAddressTransitionType =
+  'identityCreditTransferToAddresses' |
+  'identityCreateFromAddresses' |
+  'identityTopUpFromAddresses' |
+  'addressFundsTransfer' |
+  'addressFundingFromAssetLock' |
+  'addressCreditWithdrawal'
+
+const platformAddressTransitionsMap = {
+  identityCreditTransferToAddresses: {
+    class: IdentityCreditTransferToAddressesTransitionWASM,
+    arguments: ['identityId', 'recipients', 'nonce', 'userFeeIncrease'],
+    optionalArguments: ['userFeeIncrease']
+  },
+  identityCreateFromAddresses: {
+    class: IdentityCreateFromAddressesTransitionWASM,
+    arguments: ['publicKeys', 'inputs', 'feeStrategy', 'userFeeIncrease', 'inputWitness', 'output'],
+    optionalArguments: ['userFeeIncrease', 'output']
+  },
+  identityTopUpFromAddresses: {
+    class: IdentityTopUpFromAddressesTransitionWASM,
+    arguments: ['identityId', 'inputs', 'feeStrategy', 'userFeeIncrease', 'inputWitness', 'output'],
+    optionalArguments: ['userFeeIncrease', 'output']
+  },
+  addressFundsTransfer: {
+    class: AddressFundsTransferTransitionWASM,
+    arguments: ['inputs', 'feeStrategy', 'userFeeIncrease', 'inputWitness', 'outputs'],
+    optionalArguments: ['userFeeIncrease']
+  },
+  addressFundingFromAssetLock: {
+    class: AddressFundingFromAssetLockTransitionWASM,
+    arguments: ['assetLockProof', 'inputs', 'feeStrategy', 'userFeeIncrease', 'inputWitness', 'outputs'],
+    optionalArguments: ['userFeeIncrease']
+  },
+  addressCreditWithdrawal: {
+    class: AddressCreditWithdrawalTransitionWASM,
+    arguments: ['inputs', 'feeStrategy', 'coreFeePerByte', 'pooling', 'outputScript', 'userFeeIncrease', 'inputWitness', 'output'],
+    optionalArguments: ['userFeeIncrease', 'output']
+  }
+}
+
+/**
+ * Helper function that assembles a {StateTransitionWASM} for Platform Address transitions
+ * out of already-built params. The builder is pure: it does not sign, broadcast or
+ * mutate the passed params. Producing witnesses / signatures stays the caller's
+ * responsibility (they are passed in via the `inputWitness` / `signature` params).
+ *
+ * @param type {string} type of transition
+ * @param params {PlatformAddressTransitionParams} params
+ */
+export default function createStateTransition (type: PlatformAddressTransitionType, params: PlatformAddressTransitionParams): StateTransitionWASM {
+  const { class: TransitionClass, arguments: classArguments, optionalArguments } = platformAddressTransitionsMap[type] ?? {}
+
+  if (TransitionClass == null) {
+    throw new Error(`Unimplemented transition type: ${type}`)
+  }
+
+  const [missingArgument] = classArguments
+    .filter((classArgument: string) => params[classArgument] == null &&
+          !(optionalArguments).includes(classArgument))
+
+  if (missingArgument != null) {
+    throw new Error(`Platform address transition param "${missingArgument}" is missing`)
+  }
+
+  // userFeeIncrease is a required positional `number` in every WASM constructor,
+  // so coerce a missing value to 0 to keep the positional order intact.
+  const transitionParams = classArguments.map((classArgument: string) =>
+    classArgument === 'userFeeIncrease' ? (params[classArgument] ?? 0) : params[classArgument])
+
+  // @ts-expect-error
+  const platformAddressTransition = new TransitionClass(...transitionParams)
+
+  return platformAddressTransition.toStateTransition()
+}

--- a/src/platformAddresses/index.ts
+++ b/src/platformAddresses/index.ts
@@ -1,7 +1,17 @@
 import GRPCConnectionPool from '../grpcConnectionPool.js'
-import { PlatformAddressLike, StateTransitionWASM } from 'pshenmic-dpp'
+import { CoreScriptWASM, OutputAddressWASM, PlatformAddressLike, StateTransitionWASM } from 'pshenmic-dpp'
+import { base58 } from '@scure/base'
 import { getAddressInfo } from './getAddressInfo.js'
-import { PlatformAddressInfo, PlatformAddressTransitionParams } from '../../types.js'
+import {
+  CreateIdentityFromAddressesParams,
+  FundFromAssetLockParams,
+  PlatformAddressInfo,
+  PlatformAddressTransitionParams,
+  TopUpFromAddressesParams,
+  TransferBetweenAddressesParams,
+  TransferToAddressParams,
+  WithdrawalToCoreParams
+} from '../../types.js'
 import { getAddressesInfos } from './getAddressesInfos.js'
 import createStateTransition, { PlatformAddressTransitionType } from './createStateTransition.js'
 
@@ -52,5 +62,99 @@ export class PlatformAddressesController {
    */
   createStateTransition (type: PlatformAddressTransitionType, params: PlatformAddressTransitionParams): StateTransitionWASM {
     return createStateTransition(type, params)
+  }
+
+  /**
+   * Transfer credits from an Identity to one or more Platform addresses (transition type 9).
+   *
+   * Pass either a single `recipient` + `amount`, or explicit `recipients` outputs. This transition
+   * is signed by the Identity key after construction (no `inputWitness` required).
+   *
+   * @param params {TransferToAddressParams} params
+   *
+   * @return {StateTransitionWASM}
+   */
+  transferToAddress (params: TransferToAddressParams): StateTransitionWASM {
+    const recipients = params.recipients ?? (params.recipient != null && params.amount != null
+      ? [new OutputAddressWASM(params.recipient, params.amount)]
+      : undefined)
+
+    return createStateTransition('identityCreditTransferToAddresses', {
+      identityId: params.identityId,
+      recipients,
+      nonce: params.nonce,
+      userFeeIncrease: params.userFeeIncrease
+    })
+  }
+
+  /**
+   * Create a new Identity funded from Platform addresses (transition type 10).
+   *
+   * @param params {CreateIdentityFromAddressesParams} params
+   *
+   * @return {StateTransitionWASM}
+   */
+  createIdentityFromAddresses (params: CreateIdentityFromAddressesParams): StateTransitionWASM {
+    return createStateTransition('identityCreateFromAddresses', params)
+  }
+
+  /**
+   * Top up an existing Identity from Platform addresses (transition type 11).
+   *
+   * @param params {TopUpFromAddressesParams} params
+   *
+   * @return {StateTransitionWASM}
+   */
+  topUpFromAddresses (params: TopUpFromAddressesParams): StateTransitionWASM {
+    return createStateTransition('identityTopUpFromAddresses', params)
+  }
+
+  /**
+   * Transfer credits between Platform addresses (transition type 12).
+   *
+   * @param params {TransferBetweenAddressesParams} params
+   *
+   * @return {StateTransitionWASM}
+   */
+  transferBetweenAddresses (params: TransferBetweenAddressesParams): StateTransitionWASM {
+    return createStateTransition('addressFundsTransfer', params)
+  }
+
+  /**
+   * Fund Platform addresses from a Core asset lock (transition type 13).
+   *
+   * @param params {FundFromAssetLockParams} params
+   *
+   * @return {StateTransitionWASM}
+   */
+  fundFromAssetLock (params: FundFromAssetLockParams): StateTransitionWASM {
+    return createStateTransition('addressFundingFromAssetLock', params)
+  }
+
+  /**
+   * Withdraw from Platform addresses to a Core (L1) address (transition type 14).
+   *
+   * Pass either a `coreAddress` (converted to a P2PKH output script) or an explicit `outputScript`.
+   * `coreFeePerByte` defaults to 1 and `pooling` to 'Standard', mirroring the Identity withdrawal.
+   *
+   * @param params {WithdrawalToCoreParams} params
+   *
+   * @return {StateTransitionWASM}
+   */
+  withdrawalToCore (params: WithdrawalToCoreParams): StateTransitionWASM {
+    const outputScript = params.outputScript ?? (params.coreAddress != null
+      ? CoreScriptWASM.newP2PKH(base58.decode(params.coreAddress).slice(1, 21))
+      : undefined)
+
+    return createStateTransition('addressCreditWithdrawal', {
+      inputs: params.inputs,
+      feeStrategy: params.feeStrategy,
+      coreFeePerByte: params.coreFeePerByte ?? 1,
+      pooling: params.pooling ?? 'Standard',
+      outputScript,
+      inputWitness: params.inputWitness,
+      output: params.output,
+      userFeeIncrease: params.userFeeIncrease
+    })
   }
 }

--- a/src/platformAddresses/index.ts
+++ b/src/platformAddresses/index.ts
@@ -1,8 +1,9 @@
 import GRPCConnectionPool from '../grpcConnectionPool.js'
-import { PlatformAddressLike } from 'pshenmic-dpp'
+import { PlatformAddressLike, StateTransitionWASM } from 'pshenmic-dpp'
 import { getAddressInfo } from './getAddressInfo.js'
-import { PlatformAddressInfo } from '../../types.js'
+import { PlatformAddressInfo, PlatformAddressTransitionParams } from '../../types.js'
 import { getAddressesInfos } from './getAddressesInfos.js'
+import createStateTransition, { PlatformAddressTransitionType } from './createStateTransition.js'
 
 export class PlatformAddressesController {
   /** @ignore **/
@@ -30,5 +31,26 @@ export class PlatformAddressesController {
    */
   async getAddressesInfos (addresses: PlatformAddressLike[]): Promise<PlatformAddressInfo[]> {
     return await getAddressesInfos(this.grpcPool, addresses)
+  }
+
+  /**
+   * Helper function for creating {StateTransitionWASM} for Platform Address transitions
+   *
+   * Unlike identity transitions (which are signed after construction), address transitions carry
+   * their signature material as constructor input (the `inputWitness` param, and a `signature`
+   * setter on the asset-lock variant), so this builder is pure and only assembles the transition
+   * from already-built params - producing witnesses stays the caller's responsibility.
+   *
+   * Please refer to PlatformAddress.spec.ts or README for example commands
+   *
+   * @param type {string} type of transition, must be a one of ('identityCreditTransferToAddresses' |
+   * 'identityCreateFromAddresses' | 'identityTopUpFromAddresses' | 'addressFundsTransfer' |
+   * 'addressFundingFromAssetLock' | 'addressCreditWithdrawal')
+   * @param params {PlatformAddressTransitionParams} params
+   *
+   * @return {StateTransitionWASM}
+   */
+  createStateTransition (type: PlatformAddressTransitionType, params: PlatformAddressTransitionParams): StateTransitionWASM {
+    return createStateTransition(type, params)
   }
 }

--- a/test/unit/PlatformAddress.spec.ts
+++ b/test/unit/PlatformAddress.spec.ts
@@ -1,3 +1,21 @@
+import {
+  AddressFundsFeeStrategyStepWASM,
+  AddressWitnessWASM,
+  AssetLockProofWASM,
+  CoreScriptWASM,
+  IdentityPublicKeyInCreationWASM,
+  InputAddressWASM,
+  OutputAddressWASM,
+  OutputAddressNullableCreditsWASM,
+  KeyType,
+  OutPointWASM,
+  PlatformAddressWASM,
+  PrivateKeyWASM,
+  Purpose,
+  SecurityLevel,
+  StateTransitionWASM
+} from 'pshenmic-dpp'
+import { base58 } from '@scure/base'
 import { DashPlatformSDK } from '../../src/DashPlatformSDK.js'
 
 let sdk: DashPlatformSDK
@@ -24,5 +42,137 @@ describe('PlatformAddress', () => {
     const info = await sdk.platformAddresses.getAddressesInfos(addresses)
 
     expect(info).toHaveLength(addresses.length)
+  })
+
+  describe('createStateTransition', () => {
+    const identityId = 'QMfCRPcjXoTnZa9sA9JR2KWgGxZXMRJ4akgS3Uia1Qv'
+
+    const addressA = PlatformAddressWASM.fromBech32m('tdash1kzg5azscav69z7m6dfzr9ner0a5vt7pn9ca4sz8d')
+    const addressB = PlatformAddressWASM.fromBech32m('tdash1kqr3cxhgel75ru0yrhj5eq8j8jt92m5enqrfajxw')
+
+    const inputs = [new InputAddressWASM(addressA, 0, 100000n)]
+    const outputs = [new OutputAddressWASM(addressB, 50000n)]
+    const recipients = [new OutputAddressWASM(addressB, 50000n)]
+    const nullableOutputs = [new OutputAddressNullableCreditsWASM(addressB)]
+    const feeStrategy = [AddressFundsFeeStrategyStepWASM.DeductFromInput(1)]
+    const inputWitness = [AddressWitnessWASM.P2PKH(new Uint8Array(65))]
+    const output = new OutputAddressWASM(addressA, 10000n)
+    const nonce = 1n
+
+    const privateKey = PrivateKeyWASM.fromHex('a1286dd195e2b8e1f6bdc946c56a53e0c544750d6452ddc0f4c593ef311f21af', 'testnet')
+    const publicKeys = [
+      new IdentityPublicKeyInCreationWASM(0, Purpose.AUTHENTICATION, SecurityLevel.MASTER, KeyType.ECDSA_SECP256K1, false, privateKey.getPublicKey().bytes())
+    ]
+
+    const assetLockProof = AssetLockProofWASM.createChainAssetLockProof(1337, new OutPointWASM('61aede830477254876d435a317241ad46753c4b1350dc991a45ebcf19ab80a11', 0))
+
+    const withdrawalAddress = 'yjHVQ3dj37UJwXFmvMTKR9ZVfoJSc3opTD'
+    const outputScript = CoreScriptWASM.newP2PKH(base58.decode(withdrawalAddress).slice(1, 21))
+
+    test('should be able to create identityCreditTransferToAddresses', () => {
+      const stateTransition = sdk.platformAddresses.createStateTransition('identityCreditTransferToAddresses', {
+        identityId, recipients, nonce
+      })
+
+      expect(stateTransition).toEqual(expect.any(StateTransitionWASM))
+    })
+
+    test('should throw when identityCreditTransferToAddresses is missing recipients', () => {
+      expect(() => sdk.platformAddresses.createStateTransition('identityCreditTransferToAddresses', {
+        identityId, nonce
+      })).toThrow('Platform address transition param "recipients" is missing')
+    })
+
+    test('should be able to create identityCreateFromAddresses', () => {
+      const stateTransition = sdk.platformAddresses.createStateTransition('identityCreateFromAddresses', {
+        publicKeys, inputs, feeStrategy, inputWitness
+      })
+
+      expect(stateTransition).toEqual(expect.any(StateTransitionWASM))
+    })
+
+    test('should throw when identityCreateFromAddresses is missing publicKeys', () => {
+      expect(() => sdk.platformAddresses.createStateTransition('identityCreateFromAddresses', {
+        inputs, feeStrategy, inputWitness
+      })).toThrow('Platform address transition param "publicKeys" is missing')
+    })
+
+    test('should be able to create identityTopUpFromAddresses', () => {
+      const stateTransition = sdk.platformAddresses.createStateTransition('identityTopUpFromAddresses', {
+        identityId, inputs, feeStrategy, inputWitness
+      })
+
+      expect(stateTransition).toEqual(expect.any(StateTransitionWASM))
+    })
+
+    test('should throw when identityTopUpFromAddresses is missing identityId', () => {
+      expect(() => sdk.platformAddresses.createStateTransition('identityTopUpFromAddresses', {
+        inputs, feeStrategy, inputWitness
+      })).toThrow('Platform address transition param "identityId" is missing')
+    })
+
+    test('should be able to create addressFundsTransfer', () => {
+      const stateTransition = sdk.platformAddresses.createStateTransition('addressFundsTransfer', {
+        inputs, feeStrategy, inputWitness, outputs
+      })
+
+      expect(stateTransition).toEqual(expect.any(StateTransitionWASM))
+    })
+
+    test('should throw when addressFundsTransfer is missing outputs', () => {
+      expect(() => sdk.platformAddresses.createStateTransition('addressFundsTransfer', {
+        inputs, feeStrategy, inputWitness
+      })).toThrow('Platform address transition param "outputs" is missing')
+    })
+
+    test('should be able to create addressFundingFromAssetLock', () => {
+      const stateTransition = sdk.platformAddresses.createStateTransition('addressFundingFromAssetLock', {
+        assetLockProof, inputs, feeStrategy, inputWitness, outputs: nullableOutputs
+      })
+
+      expect(stateTransition).toEqual(expect.any(StateTransitionWASM))
+    })
+
+    test('should throw when addressFundingFromAssetLock is missing assetLockProof', () => {
+      expect(() => sdk.platformAddresses.createStateTransition('addressFundingFromAssetLock', {
+        inputs, feeStrategy, inputWitness, outputs: nullableOutputs
+      })).toThrow('Platform address transition param "assetLockProof" is missing')
+    })
+
+    test('should be able to create addressCreditWithdrawal', () => {
+      const stateTransition = sdk.platformAddresses.createStateTransition('addressCreditWithdrawal', {
+        inputs, feeStrategy, coreFeePerByte: 1, pooling: 'Standard', outputScript, inputWitness
+      })
+
+      expect(stateTransition).toEqual(expect.any(StateTransitionWASM))
+    })
+
+    test('should be able to create addressCreditWithdrawal with optional output', () => {
+      const stateTransition = sdk.platformAddresses.createStateTransition('addressCreditWithdrawal', {
+        inputs, feeStrategy, coreFeePerByte: 1, pooling: 'Standard', outputScript, inputWitness, output
+      })
+
+      expect(stateTransition).toEqual(expect.any(StateTransitionWASM))
+    })
+
+    test('should throw when addressCreditWithdrawal is missing outputScript', () => {
+      expect(() => sdk.platformAddresses.createStateTransition('addressCreditWithdrawal', {
+        inputs, feeStrategy, coreFeePerByte: 1, pooling: 'Standard', inputWitness
+      })).toThrow('Platform address transition param "outputScript" is missing')
+    })
+
+    test('should default userFeeIncrease to 0 when omitted', () => {
+      const stateTransition = sdk.platformAddresses.createStateTransition('addressFundsTransfer', {
+        inputs, feeStrategy, inputWitness, outputs
+      })
+
+      expect(stateTransition).toEqual(expect.any(StateTransitionWASM))
+    })
+
+    test('should throw on unimplemented transition type', () => {
+      expect(() => sdk.platformAddresses.createStateTransition(
+        // @ts-expect-error testing an unknown transition type
+        'unknownTransition', {})).toThrow('Unimplemented transition type: unknownTransition')
+    })
   })
 })

--- a/test/unit/PlatformAddress.spec.ts
+++ b/test/unit/PlatformAddress.spec.ts
@@ -175,4 +175,100 @@ describe('PlatformAddress', () => {
         'unknownTransition', {})).toThrow('Unimplemented transition type: unknownTransition')
     })
   })
+
+  describe('convenience builders', () => {
+    const identityId = 'QMfCRPcjXoTnZa9sA9JR2KWgGxZXMRJ4akgS3Uia1Qv'
+
+    const addressA = PlatformAddressWASM.fromBech32m('tdash1kzg5azscav69z7m6dfzr9ner0a5vt7pn9ca4sz8d')
+    const addressB = PlatformAddressWASM.fromBech32m('tdash1kqr3cxhgel75ru0yrhj5eq8j8jt92m5enqrfajxw')
+
+    const inputs = [new InputAddressWASM(addressA, 0, 100000n)]
+    const outputs = [new OutputAddressWASM(addressB, 50000n)]
+    const nullableOutputs = [new OutputAddressNullableCreditsWASM(addressB)]
+    const feeStrategy = [AddressFundsFeeStrategyStepWASM.DeductFromInput(1)]
+    const inputWitness = [AddressWitnessWASM.P2PKH(new Uint8Array(65))]
+
+    const privateKey = PrivateKeyWASM.fromHex('a1286dd195e2b8e1f6bdc946c56a53e0c544750d6452ddc0f4c593ef311f21af', 'testnet')
+    const publicKeys = [
+      new IdentityPublicKeyInCreationWASM(0, Purpose.AUTHENTICATION, SecurityLevel.MASTER, KeyType.ECDSA_SECP256K1, false, privateKey.getPublicKey().bytes())
+    ]
+
+    const assetLockProof = AssetLockProofWASM.createChainAssetLockProof(1337, new OutPointWASM('61aede830477254876d435a317241ad46753c4b1350dc991a45ebcf19ab80a11', 0))
+
+    test('transferToAddress builds a recipient from address + amount', () => {
+      const stateTransition = sdk.platformAddresses.transferToAddress({
+        identityId, recipient: addressB, amount: 50000n, nonce: 1n
+      })
+
+      expect(stateTransition).toEqual(expect.any(StateTransitionWASM))
+    })
+
+    test('transferToAddress accepts explicit recipients', () => {
+      const stateTransition = sdk.platformAddresses.transferToAddress({
+        identityId, recipients: outputs, nonce: 1n
+      })
+
+      expect(stateTransition).toEqual(expect.any(StateTransitionWASM))
+    })
+
+    test('transferToAddress throws when no recipient is provided', () => {
+      expect(() => sdk.platformAddresses.transferToAddress({ identityId, nonce: 1n }))
+        .toThrow('Platform address transition param "recipients" is missing')
+    })
+
+    test('createIdentityFromAddresses', () => {
+      const stateTransition = sdk.platformAddresses.createIdentityFromAddresses({
+        publicKeys, inputs, feeStrategy, inputWitness
+      })
+
+      expect(stateTransition).toEqual(expect.any(StateTransitionWASM))
+    })
+
+    test('topUpFromAddresses', () => {
+      const stateTransition = sdk.platformAddresses.topUpFromAddresses({
+        identityId, inputs, feeStrategy, inputWitness
+      })
+
+      expect(stateTransition).toEqual(expect.any(StateTransitionWASM))
+    })
+
+    test('transferBetweenAddresses', () => {
+      const stateTransition = sdk.platformAddresses.transferBetweenAddresses({
+        inputs, feeStrategy, inputWitness, outputs
+      })
+
+      expect(stateTransition).toEqual(expect.any(StateTransitionWASM))
+    })
+
+    test('fundFromAssetLock', () => {
+      const stateTransition = sdk.platformAddresses.fundFromAssetLock({
+        assetLockProof, inputs, feeStrategy, inputWitness, outputs: nullableOutputs
+      })
+
+      expect(stateTransition).toEqual(expect.any(StateTransitionWASM))
+    })
+
+    test('withdrawalToCore builds outputScript from a Core address', () => {
+      const stateTransition = sdk.platformAddresses.withdrawalToCore({
+        inputs, feeStrategy, inputWitness, coreAddress: 'yjHVQ3dj37UJwXFmvMTKR9ZVfoJSc3opTD'
+      })
+
+      expect(stateTransition).toEqual(expect.any(StateTransitionWASM))
+    })
+
+    test('withdrawalToCore accepts an explicit outputScript', () => {
+      const outputScript = CoreScriptWASM.newP2PKH(base58.decode('yjHVQ3dj37UJwXFmvMTKR9ZVfoJSc3opTD').slice(1, 21))
+
+      const stateTransition = sdk.platformAddresses.withdrawalToCore({
+        inputs, feeStrategy, inputWitness, outputScript
+      })
+
+      expect(stateTransition).toEqual(expect.any(StateTransitionWASM))
+    })
+
+    test('withdrawalToCore throws when no output script is provided', () => {
+      expect(() => sdk.platformAddresses.withdrawalToCore({ inputs, feeStrategy, inputWitness }))
+        .toThrow('Platform address transition param "outputScript" is missing')
+    })
+  })
 })

--- a/types.ts
+++ b/types.ts
@@ -3,7 +3,7 @@ import {
   DocumentWASM,
   GasFeesPaidByWASM, IdentifierLike,
   IdentifierWASM,
-  KeyType, PlatformAddressWASM, Purpose, SecurityLevel,
+  KeyType, PlatformAddressLike, PlatformAddressWASM, Purpose, SecurityLevel,
   TokenEmergencyActionWASM,
   TokenPricingScheduleWASM,
   AddressFundsFeeStrategyStepWASM,
@@ -301,5 +301,70 @@ export interface PlatformAddressTransitionParams {
   coreFeePerByte?: number
   pooling?: 'Standard' | 'Never' | 'IfAvailable'
   outputScript?: CoreScriptWASM
+  userFeeIncrease?: number
+}
+
+/**
+ * The `inputWitness` arrays carried by the address-funded transitions below are produced by the
+ * client application (wallet / mobile / browser extension), which is where the address private keys
+ * live. These convenience builders only assemble the transition - they never sign or hit the network.
+ */
+export interface TransferToAddressParams {
+  identityId: IdentifierLike
+  nonce: bigint
+  /** A single recipient address; combined with `amount` to build a recipient output **/
+  recipient?: PlatformAddressLike
+  amount?: bigint
+  /** Pass explicit recipient outputs instead of `recipient` + `amount` **/
+  recipients?: OutputAddressWASM[]
+  userFeeIncrease?: number
+}
+
+export interface CreateIdentityFromAddressesParams {
+  publicKeys: IdentityPublicKeyInCreationWASM[]
+  inputs: InputAddressWASM[]
+  feeStrategy: AddressFundsFeeStrategyStepWASM[]
+  inputWitness: AddressWitnessWASM[]
+  output?: OutputAddressWASM
+  userFeeIncrease?: number
+}
+
+export interface TopUpFromAddressesParams {
+  identityId: IdentifierLike
+  inputs: InputAddressWASM[]
+  feeStrategy: AddressFundsFeeStrategyStepWASM[]
+  inputWitness: AddressWitnessWASM[]
+  output?: OutputAddressWASM
+  userFeeIncrease?: number
+}
+
+export interface TransferBetweenAddressesParams {
+  inputs: InputAddressWASM[]
+  feeStrategy: AddressFundsFeeStrategyStepWASM[]
+  inputWitness: AddressWitnessWASM[]
+  outputs: OutputAddressWASM[]
+  userFeeIncrease?: number
+}
+
+export interface FundFromAssetLockParams {
+  assetLockProof: AssetLockProofWASM
+  inputs: InputAddressWASM[]
+  feeStrategy: AddressFundsFeeStrategyStepWASM[]
+  inputWitness: AddressWitnessWASM[]
+  outputs: OutputAddressNullableCreditsWASM[]
+  userFeeIncrease?: number
+}
+
+export interface WithdrawalToCoreParams {
+  inputs: InputAddressWASM[]
+  feeStrategy: AddressFundsFeeStrategyStepWASM[]
+  inputWitness: AddressWitnessWASM[]
+  /** A Core (L1) address; converted to a P2PKH `outputScript` **/
+  coreAddress?: string
+  /** Pass an explicit output script instead of `coreAddress` **/
+  outputScript?: CoreScriptWASM
+  coreFeePerByte?: number
+  pooling?: 'Standard' | 'Never' | 'IfAvailable'
+  output?: OutputAddressWASM
   userFeeIncrease?: number
 }

--- a/types.ts
+++ b/types.ts
@@ -5,7 +5,14 @@ import {
   IdentifierWASM,
   KeyType, PlatformAddressWASM, Purpose, SecurityLevel,
   TokenEmergencyActionWASM,
-  TokenPricingScheduleWASM
+  TokenPricingScheduleWASM,
+  AddressFundsFeeStrategyStepWASM,
+  AddressWitnessWASM,
+  AssetLockProofWASM,
+  IdentityPublicKeyInCreationWASM,
+  InputAddressWASM,
+  OutputAddressWASM,
+  OutputAddressNullableCreditsWASM
 } from 'pshenmic-dpp'
 
 export {
@@ -26,7 +33,20 @@ export {
   IdentityCreditTransferWASM,
   MasternodeVoteTransitionWASM,
   IdentifierLike,
-  PlatformAddressLike
+  PlatformAddressLike,
+  InputAddressWASM,
+  OutputAddressWASM,
+  OutputAddressNullableCreditsWASM,
+  AddressFundsFeeStrategyStepWASM,
+  AddressWitnessWASM,
+  IdentityPublicKeyInCreationWASM,
+  AssetLockProofWASM,
+  IdentityCreditTransferToAddressesTransitionWASM,
+  IdentityCreateFromAddressesTransitionWASM,
+  IdentityTopUpFromAddressesTransitionWASM,
+  AddressFundsTransferTransitionWASM,
+  AddressFundingFromAssetLockTransitionWASM,
+  AddressCreditWithdrawalTransitionWASM
 } from 'pshenmic-dpp'
 
 export type Network = 'mainnet' | 'testnet'
@@ -265,4 +285,21 @@ export interface PlatformAddressInfo {
   address: PlatformAddressWASM
   nonce: number
   balance: bigint
+}
+
+export interface PlatformAddressTransitionParams {
+  identityId?: IdentifierLike
+  publicKeys?: IdentityPublicKeyInCreationWASM[]
+  inputs?: InputAddressWASM[]
+  outputs?: OutputAddressWASM[] | OutputAddressNullableCreditsWASM[]
+  recipients?: OutputAddressWASM[]
+  output?: OutputAddressWASM
+  feeStrategy?: AddressFundsFeeStrategyStepWASM[]
+  inputWitness?: AddressWitnessWASM[]
+  assetLockProof?: AssetLockProofWASM
+  nonce?: bigint
+  coreFeePerByte?: number
+  pooling?: 'Standard' | 'Never' | 'IfAvailable'
+  outputScript?: CoreScriptWASM
+  userFeeIncrease?: number
 }


### PR DESCRIPTION
Adds `sdk.platformAddresses.createStateTransition(type, params)`, a pure high-level builder for the six Platform Address state transitions (types 9–14), mirroring the existing `IdentitiesController.createStateTransition` pattern:

- `identityCreditTransferToAddresses`
- `identityCreateFromAddresses`
- `identityTopUpFromAddresses`
- `addressFundsTransfer`
- `addressFundingFromAssetLock`
- `addressCreditWithdrawal`

Also re-exports the supporting entity classes and the six transition WASM classes from the SDK entry, adds the `PlatformAddressTransitionParams` type, and unit tests covering every type plus missing-required-arg errors.

The builder is pure: no signing, broadcasting, or network calls — witnesses/signatures are caller-provided via `inputWitness`.