### PR TITLE
Implement `getFinalizedEpochsInfo` method

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,6 +59,6 @@
     "@scure/bip39": "^2.0.0",
     "@scure/btc-signer": "^2.0.1",
     "cbor-x": "^1.6.0",
-    "pshenmic-dpp": "2.0.0-dev.22"
+    "pshenmic-dpp": "2.0.0-dev.23"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dash-platform-sdk",
-  "version": "1.5.0-dev.1",
+  "version": "1.5.0-dev.2",
   "main": "index.js",
   "description": "Lightweight SDK for accessing Dash Platform blockchain",
   "repository": {

--- a/proto/platform.proto
+++ b/proto/platform.proto
@@ -30,6 +30,8 @@ service Platform {
   rpc getIdentityByNonUniquePublicKeyHash(GetIdentityByNonUniquePublicKeyHashRequest)
       returns (GetIdentityByNonUniquePublicKeyHashResponse);
   rpc getEpochsInfo(GetEpochsInfoRequest) returns (GetEpochsInfoResponse);
+  rpc getFinalizedEpochInfos(GetFinalizedEpochInfosRequest)
+        returns (GetFinalizedEpochInfosResponse);
   rpc getContestedResources(GetContestedResourcesRequest)
       returns (GetContestedResourcesResponse);
   rpc getContestedResourceVoteState(GetContestedResourceVoteStateRequest)
@@ -1160,4 +1162,71 @@ message GetShieldedNullifiersResponse {
     ResponseMetadata metadata = 3;
   }
   oneof version { GetShieldedNullifiersResponseV0 v0 = 1; }
+}
+
+message GetFinalizedEpochInfosRequest {
+  message GetFinalizedEpochInfosRequestV0 {
+    uint32 start_epoch_index = 1;        // The starting epoch index
+    bool start_epoch_index_included = 2; // Whether to include the start epoch
+    uint32 end_epoch_index = 3;          // The ending epoch index
+    bool end_epoch_index_included = 4;   // Whether to include the end epoch
+    bool prove = 5; // Flag to request a proof as the response
+  }
+
+  oneof version { GetFinalizedEpochInfosRequestV0 v0 = 1; }
+}
+
+message GetFinalizedEpochInfosResponse {
+  message GetFinalizedEpochInfosResponseV0 {
+    // FinalizedEpochInfos holds a collection of finalized epoch information
+    // entries
+    message FinalizedEpochInfos {
+      repeated FinalizedEpochInfo finalized_epoch_infos =
+          1; // List of finalized information for each requested epoch
+    }
+
+    // FinalizedEpochInfo represents finalized information about a single epoch
+    message FinalizedEpochInfo {
+      uint32 number = 1; // The number of the epoch
+      uint64 first_block_height = 2
+          [ jstype = JS_STRING ]; // The height of the first block in this epoch
+      uint32 first_core_block_height =
+          3; // The height of the first Core block in this epoch
+      uint64 first_block_time = 4
+          [ jstype =
+                JS_STRING ]; // The timestamp of the first block (milliseconds)
+      double fee_multiplier = 5; // The fee multiplier (converted from permille)
+      uint32 protocol_version = 6; // The protocol version for this epoch
+      uint64 total_blocks_in_epoch = 7
+          [ jstype = JS_STRING ]; // Total number of blocks in the epoch
+      uint32 next_epoch_start_core_block_height =
+          8; // Core block height where next epoch starts
+      uint64 total_processing_fees = 9
+          [ jstype = JS_STRING ]; // Total processing fees collected
+      uint64 total_distributed_storage_fees = 10
+          [ jstype = JS_STRING ]; // Total storage fees distributed
+      uint64 total_created_storage_fees = 11
+          [ jstype = JS_STRING ]; // Total storage fees created
+      uint64 core_block_rewards = 12
+          [ jstype = JS_STRING ]; // Rewards from core blocks
+      repeated BlockProposer block_proposers =
+          13; // List of block proposers and their counts
+    }
+
+    // BlockProposer represents a block proposer and their block count
+    message BlockProposer {
+      bytes proposer_id = 1;  // The proposer's identifier
+      uint32 block_count = 2; // Number of blocks proposed
+    }
+
+    oneof result {
+      FinalizedEpochInfos epochs =
+          1; // The actual finalized information about the requested epochs
+      Proof proof = 2; // Cryptographic proof of the finalized epoch
+                       // information, if requested
+    }
+    ResponseMetadata metadata = 3; // Metadata about the blockchain state
+  }
+
+  oneof version { GetFinalizedEpochInfosResponseV0 v0 = 1; }
 }

--- a/src/node/epochInfos.ts
+++ b/src/node/epochInfos.ts
@@ -16,7 +16,7 @@ export interface EpochInfo {
   protocolVersion: 9
 }
 
-export default async function epochs (grpcPool: GRPCConnectionPool, count: number, ascending: boolean, start?: number): Promise<EpochInfo[]> {
+export default async function epochInfos (grpcPool: GRPCConnectionPool, count: number, ascending: boolean, start?: number): Promise<EpochInfo[]> {
   const getEpochsInfoRequest = GetEpochsInfoRequest.create({
     version: {
       oneofKind: 'v0',

--- a/src/node/finalizedEpochInfos.ts
+++ b/src/node/finalizedEpochInfos.ts
@@ -1,0 +1,96 @@
+import GRPCConnectionPool from '../grpcConnectionPool.js'
+import {GetFinalizedEpochInfosRequest} from '../../proto/generated/platform.js'
+import {IdentifierWASM, verifyFinalizedEpochInfosProof} from 'pshenmic-dpp'
+import { getQuorumPublicKey } from '../utils/getQuorumPublicKey.js'
+import bytesToHex from '../utils/bytesToHex.js'
+import verifyTenderdashProof from '../utils/verifyTenderdashProof.js'
+import { LATEST_PLATFORM_VERSION } from '../constants.js'
+
+export interface FinalizedEpochInfo {
+  epochIndex: number,
+  firstBlockTime: Date,
+  firstBlockHeight: bigint,
+  totalBlocksInEpoch: bigint,
+  firstCoreBlockHeight: number,
+  nextEpochStartCoreBlockHeight: number,
+  totalProcessingFees: bigint,
+  totalDistributedStorageFees: bigint,
+  totalCreatedStorageFees: bigint,
+  coreBlockRewards: bigint,
+  blockProposers: {
+    proposer: IdentifierWASM;
+    count: bigint;
+  }[],
+  feeMultiplier: bigint,
+  protocolVersion: number
+}
+
+export default async function getFinalizedEpochsInfo (grpcPool: GRPCConnectionPool, startEpochIndex: number, startEpochIndexIncluded: boolean, endEpochIndex: number, endEpochIndexIncluded: boolean): Promise<FinalizedEpochInfo[]> {
+  const getEpochsInfoRequest = GetFinalizedEpochInfosRequest.create({
+    version: {
+      oneofKind: 'v0',
+      v0: {
+        startEpochIndex,
+        startEpochIndexIncluded,
+        endEpochIndex,
+        endEpochIndexIncluded,
+        prove: true
+      }
+    }
+  })
+
+  const { response } = await grpcPool.getClient().getFinalizedEpochInfos(getEpochsInfoRequest)
+
+  const { version } = response
+
+  if (version.oneofKind !== 'v0') {
+    throw new Error('Unexpected oneOf type returned from DAPI (must be v0)')
+  }
+
+  const { v0 } = version
+
+  if (v0.result.oneofKind !== 'proof') {
+    throw new Error('Unexpected oneOf type returned from DAPI (must be proof)')
+  }
+
+  const { result: { proof }, metadata } = v0
+
+  if (metadata == null) {
+    throw new Error('Metadata not found')
+  }
+
+  const {
+    rootHash,
+    epochInfos
+  } = verifyFinalizedEpochInfosProof(
+    proof.grovedbProof,
+    startEpochIndex,
+    startEpochIndexIncluded,
+    endEpochIndex,
+    endEpochIndexIncluded,
+    LATEST_PLATFORM_VERSION
+  )
+  const quorumPublicKey = await getQuorumPublicKey(grpcPool.network, proof.quorumType, bytesToHex(proof.quorumHash))
+
+  const verify = await verifyTenderdashProof(proof, metadata, rootHash, quorumPublicKey)
+
+  if (!verify) {
+    throw new Error('Failed to verify query')
+  }
+
+  return epochInfos.map(info => ({
+    epochIndex: info.epochIndex,
+    firstBlockTime: info.firstBlockTime,
+    firstBlockHeight: info.firstBlockHeight,
+    totalBlocksInEpoch: info.totalBlocksInEpoch,
+    firstCoreBlockHeight: info.firstCoreBlockHeight,
+    nextEpochStartCoreBlockHeight: info.nextEpochStartCoreBlockHeight,
+    totalProcessingFees: info.totalProcessingFees,
+    totalDistributedStorageFees: info.totalDistributedStorageFees,
+    totalCreatedStorageFees: info.totalCreatedStorageFees,
+    coreBlockRewards: info.coreBlockRewards,
+    blockProposers: info.blockProposers,
+    feeMultiplier: info.feeMultiplierPermille,
+    protocolVersion: info.protocolVersion
+  })) as unknown as FinalizedEpochInfo[]
+}

--- a/src/node/index.ts
+++ b/src/node/index.ts
@@ -51,7 +51,7 @@ export class NodeController {
    * Retrieves an finalized info about epochs
    * Includes information about first block height, time, fee multiplier, number
    *
-   * @return {Promise<EpochInfo[]>}
+   * @return {Promise<FinalizedEpochInfo[]>}
    */
   async getFinalizedEpochsInfo (startEpochIndex: number, startEpochIndexIncluded: boolean, endEpochIndex: number, endEpochIndexIncluded: boolean): Promise<FinalizedEpochInfo[]> {
     return await getFinalizedEpochsInfo(this.grpcPool, startEpochIndex, startEpochIndexIncluded, endEpochIndex, endEpochIndexIncluded)

--- a/src/node/index.ts
+++ b/src/node/index.ts
@@ -1,7 +1,8 @@
 import getStatus from './status.js'
 import GRPCConnectionPool from '../grpcConnectionPool.js'
 import { NodeStatus } from '../../types.js'
-import getEpochsInfo, { EpochInfo } from './epochs.js'
+import getEpochsInfo, { EpochInfo } from './epochInfos.js'
+import getFinalizedEpochsInfo, {FinalizedEpochInfo} from './finalizedEpochInfos.js'
 import getTotalCredits from './totalCredits.js'
 
 /**
@@ -45,4 +46,15 @@ export class NodeController {
   async getEpochsInfo (count: number, ascending: boolean, start?: number): Promise<EpochInfo[]> {
     return await getEpochsInfo(this.grpcPool, count, ascending, start)
   }
+
+  /**
+   * Retrieves an finalized info about epochs
+   * Includes information about first block height, time, fee multiplier, number
+   *
+   * @return {Promise<EpochInfo[]>}
+   */
+  async getFinalizedEpochsInfo (startEpochIndex: number, startEpochIndexIncluded: boolean, endEpochIndex: number, endEpochIndexIncluded: boolean): Promise<FinalizedEpochInfo[]> {
+    return await getFinalizedEpochsInfo(this.grpcPool, startEpochIndex, startEpochIndexIncluded, endEpochIndex, endEpochIndexIncluded)
+  }
+
 }

--- a/test/unit/Node.spec.ts
+++ b/test/unit/Node.spec.ts
@@ -69,6 +69,15 @@ describe('Node', () => {
     expect(epochsInfo.map(epochInfo => epochInfo.number)).toEqual(expectedEpochsNumbers)
   })
 
+  test('should be able to call getFinalizedEpochInfos', async () => {
+    const epochsInfo = await sdk.node.getFinalizedEpochsInfo(17100, true, 17110, false)
+
+    const expectedEpochsNumbers = Array.from({ length: 10 }, (_val, index) => 17100 + index)
+
+    expect(epochsInfo.length).toEqual(10)
+    expect(epochsInfo.map(epochInfo => epochInfo.epochIndex)).toEqual(expectedEpochsNumbers)
+  })
+
   test('should be able to call getTotalCreditsInPlatform', async () => {
     const totalCredits = await sdk.node.totalCredits()
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5243,10 +5243,10 @@ protoc@^32.1.0:
   resolved "https://registry.npmjs.org/protoc/-/protoc-32.1.0.tgz"
   integrity sha512-yICJJCGHJLM9ao5W2V4CGp1d7xuBsdHzgVDw6L8mdDtoIcqzN3arNPOm9Jx4Ufp5vfhQfJGkNUDo6mm/SLPdXw==
 
-pshenmic-dpp@2.0.0-dev.22:
-  version "2.0.0-dev.22"
-  resolved "https://registry.yarnpkg.com/pshenmic-dpp/-/pshenmic-dpp-2.0.0-dev.22.tgz#19ce213ca2ae20df5a1e846d9b08b625c0e5b972"
-  integrity sha512-maB6DGEHhnF6yFFjaeLIe0j6HNz2YtBcd+MDxkm+WNA66ufujAyP5ZK9FbPvvX7hFjMT1wdcv8VLzbw7vEaRTg==
+pshenmic-dpp@2.0.0-dev.23:
+  version "2.0.0-dev.23"
+  resolved "https://registry.yarnpkg.com/pshenmic-dpp/-/pshenmic-dpp-2.0.0-dev.23.tgz#bbc798486d10d304c57bea157953642c7ea77ee4"
+  integrity sha512-Q/fvDf6PZIsLPhKTbmKReSyRUjgFcjTtvucFJlfdfSO85frMLxF7BAL3iKWrtW180IvJNEAFE/I3QBlvGjAwJQ==
   dependencies:
     "@emnapi/core" "1.9.0"
     "@emnapi/runtime" "1.9.0"


### PR DESCRIPTION
# Issue
New info for Platform-Explorer requires `getFinalizedEpochsInfo` method in sdk

# Things done
- Updated `platform.proto` file for new endpoint
- [Updated pshenmic-dpp to 2.0.0-dev.23](https://github.com/owl352/pshenmic-dpp/releases/tag/2.0.0-dev.23) which now includes `verifyFinalizedEpochInfosProof`
- Implemented `getFinalizedEpochsInfo` method
- Updated naming for `getEpochsInfo`
- Implement new test
- Bump package version