### PR TITLE
Async Shielded builder

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dash-platform-sdk",
-  "version": "1.5.0-dev.2",
+  "version": "1.5.0-dev.3",
   "main": "index.js",
   "description": "Lightweight SDK for accessing Dash Platform blockchain",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "@babel/preset-env": "^7.28.0",
     "@babel/preset-typescript": "^7.27.1",
     "@protobuf-ts/plugin": "^2.11.1",
-    "@rollup/plugin-commonjs": "^28.0.6",
+    "@rollup/plugin-alias": "^6.0.0",
+    "@rollup/plugin-commonjs": "^29.0.3",
     "@rollup/plugin-node-resolve": "^16.0.1",
     "@rollup/plugin-terser": "^0.4.4",
     "@rollup/plugin-typescript": "^12.1.4",
@@ -59,6 +60,6 @@
     "@scure/bip39": "^2.0.0",
     "@scure/btc-signer": "^2.0.1",
     "cbor-x": "^1.6.0",
-    "pshenmic-dpp": "2.0.0-dev.23"
+    "pshenmic-dpp": "2.0.0-dev.24"
   }
 }

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,23 +1,49 @@
 import resolve from '@rollup/plugin-node-resolve'
 import typescript from '@rollup/plugin-typescript'
 import terser from '@rollup/plugin-terser'
+import alias from '@rollup/plugin-alias'
+import path from 'path'
+import commonjs from '@rollup/plugin-commonjs'
 
 export default [
   {
     onwarn: function (warning, handler) {
-      if (warning.code === 'THIS_IS_UNDEFINED' || (warning?.loc?.file?.indexOf('@scure') !== -1 && warning.pluginCode === 'TS2345')) {
+      // `worker_threads` is intentionally external (Node-only, guarded by isNode)
+      if (warning.code === 'THIS_IS_UNDEFINED' ||
+        warning.code === 'MISSING_NODE_BUILTINS' ||
+        (warning?.loc?.file?.indexOf('@scure') !== -1 && warning.pluginCode === 'TS2345')) {
         return
       }
 
       handler(warning)
     },
     input: 'index.ts',
+    // pshenmic-dpp's wasm loader references `worker_threads` behind an `isNode`
+    // runtime guard; it's never reached in the browser, so keep it out of the
+    // bundle instead of trying to shim a Node built-in.
+    external: ['worker_threads'],
     output: {
       name: 'DashPlatformSDK',
       file: 'dist/bundle.min.js',
-      format: 'umd'
+      format: 'umd',
+      globals: {
+        worker_threads: 'worker_threads'
+      }
     },
     plugins: [
+      alias({
+        entries: [
+          {
+            find: 'pshenmic-dpp',
+            replacement: path.resolve(
+              'node_modules/pshenmic-dpp/dist/src/wasm.js'
+            )
+          }
+        ]
+      }),
+      commonjs({
+        transformMixedEsModules: true
+      }),
       typescript({
         include: [
           './proto/generated/**/*',
@@ -27,34 +53,20 @@ export default [
       }),
       // babel(),
       resolve({
-        'pshenmic-dpp': true
-      }), // so Rollup can find `ms`
+        browser: true,
+        preferBuiltins: false
+      }),
       terser({
-        parse: {
-          // parse options
-        },
-        compress: {
-          // compress options
-        },
-        mangle: {
-          // mangle options
-
-          properties: {
-            // mangle property options
-          }
-        },
-        format: {
-          // format options (can also use `output` for backwards compatibility)
-        },
-        ecma: 5, // specify one of: 5, 2015, 2016, etc.
-        enclose: false, // or specify true, or "args:values"
-        keep_classnames: false,
+        // ecma 2020: the wasm glue uses BigInt/modern syntax; ES5 downleveling is unsafe
+        ecma: 2020,
+        compress: true,
+        // property mangling MUST stay off: NAPI bindings, protobuf and cbor all
+        // access properties by name, so renaming them corrupts the bundle
+        mangle: { properties: false },
+        // the SDK relies on WASM class identity (instanceof StateTransitionWASM, etc.)
+        keep_classnames: true,
         keep_fnames: false,
-        ie8: false,
-        module: false,
-        nameCache: null, // or specify a name cache object
-        safari10: false,
-        toplevel: false
+        format: { comments: false }
       })
     ]
   }

--- a/src/shielded/createStateTransition.ts
+++ b/src/shielded/createStateTransition.ts
@@ -40,11 +40,11 @@ const shieldedTransitionsMap = {
   }
 }
 
-export default function createStateTransition<K extends ShieldedTransitionType> (
+export default async function createStateTransition<K extends ShieldedTransitionType> (
   builder: ShieldedBuilderWASM,
   type: K,
   params: ShieldedTransitionParamsMap[K]
-): StateTransitionWASM {
+): Promise<StateTransitionWASM> {
   const { method: builderMethod, arguments: classArguments, optionalArguments } = shieldedTransitionsMap[type]
 
   if (builderMethod == null) {
@@ -60,7 +60,7 @@ export default function createStateTransition<K extends ShieldedTransitionType> 
 
   const transitionParams = classArguments.concat(optionalArguments).map((classArgument: string) => params[classArgument as keyof ShieldedTransitionParamsMap[K]])
 
-  const result = builderMethod.apply(builder, [...transitionParams, params.platformVersion ?? LATEST_PLATFORM_VERSION])
+  const result = await builderMethod.apply(builder, [...transitionParams, params.platformVersion ?? LATEST_PLATFORM_VERSION])
 
   if (result instanceof StateTransitionWASM) {
     return result

--- a/src/shielded/index.ts
+++ b/src/shielded/index.ts
@@ -38,7 +38,7 @@ export class ShieldedController {
   /** @ignore **/
   shieldedBuilder?: ShieldedBuilderWASM
 
-  constructor (grpcPool: GRPCConnectionPool) {
+  constructor(grpcPool: GRPCConnectionPool) {
     this.grpcPool = grpcPool
   }
 
@@ -46,11 +46,13 @@ export class ShieldedController {
    * Set bindings instance of builder
    * Needed for custom builder load, because ShieldedBuilderWASM inits very slow on old hardware
    */
-  init(builder?: ShieldedBuilderWASM): ShieldedBuilderWASM {
+  async init(builder?: ShieldedBuilderWASM): Promise<ShieldedBuilderWASM> {
     this.shieldedBuilder = builder ?? new ShieldedBuilderWASM()
 
+    await this.shieldedBuilder.init()
+
     return this.shieldedBuilder
-}
+  }
 
   /**
    * Lazily constructs and caches a {ShieldedBuilderWASM}. Construction builds
@@ -58,9 +60,9 @@ export class ShieldedController {
    *
    * @ignore
    */
-  getShieldedBuilder (): ShieldedBuilderWASM {
+  async getShieldedBuilder(): Promise<ShieldedBuilderWASM> {
     if (this.shieldedBuilder == null) {
-      return this.init()
+      return await this.init()
     }
 
     return this.shieldedBuilder
@@ -78,7 +80,7 @@ export class ShieldedController {
    *
    * @return {Promise<ShieldedEncryptedNote[]>}
    */
-  async getShieldedEncryptedNotes (startIndex: bigint, count: number): Promise<ShieldedEncryptedNote[]> {
+  async getShieldedEncryptedNotes(startIndex: bigint, count: number): Promise<ShieldedEncryptedNote[]> {
     return await getShieldedEncryptedNotes(this.grpcPool, startIndex, count)
   }
 
@@ -88,7 +90,7 @@ export class ShieldedController {
    *
    * @return {Promise<Uint8Array[]>}
    */
-  async getShieldedAnchors (): Promise<Uint8Array[]> {
+  async getShieldedAnchors(): Promise<Uint8Array[]> {
     return await getShieldedAnchors(this.grpcPool)
   }
 
@@ -97,7 +99,7 @@ export class ShieldedController {
    *
    * @return {Promise<Uint8Array>}
    */
-  async getMostRecentShieldedAnchor (): Promise<Uint8Array | undefined> {
+  async getMostRecentShieldedAnchor(): Promise<Uint8Array | undefined> {
     return await getMostRecentShieldedAnchor(this.grpcPool)
   }
 
@@ -106,7 +108,7 @@ export class ShieldedController {
    *
    * @return {Promise<bigint>}
    */
-  async getShieldedPoolState (): Promise<bigint | undefined> {
+  async getShieldedPoolState(): Promise<bigint | undefined> {
     return await getShieldedPoolState(this.grpcPool)
   }
 
@@ -116,7 +118,7 @@ export class ShieldedController {
    *
    * @return {Promise<bigint>}
    */
-  async getShieldedNotesCount (): Promise<bigint | undefined> {
+  async getShieldedNotesCount(): Promise<bigint | undefined> {
     return await getShieldedNotesCount(this.grpcPool)
   }
 
@@ -130,7 +132,7 @@ export class ShieldedController {
    *
    * @return {Promise<ShieldedNullifierStatus[]>}
    */
-  async getShieldedNullifiers (nullifiers: Uint8Array[]): Promise<ShieldedNullifierStatus[]> {
+  async getShieldedNullifiers(nullifiers: Uint8Array[]): Promise<ShieldedNullifierStatus[]> {
     return await getShieldedNullifiers(this.grpcPool, nullifiers)
   }
 
@@ -147,7 +149,7 @@ export class ShieldedController {
    *
    * @return {RecoveredNoteWASM[]}
    */
-  recoverNotes (notes: ShieldedEncryptedNote[], seed: Uint8Array, account: number): RecoveredNoteWASM[] {
+  recoverNotes(notes: ShieldedEncryptedNote[], seed: Uint8Array, account: number): RecoveredNoteWASM[] {
     // SLIP-44 coin type: 5 = Dash mainnet, 1 = testnets. Orchard derives via ZIP-32
     const coinType = this.grpcPool.network === 'mainnet' ? 5 : 1
 
@@ -175,7 +177,10 @@ export class ShieldedController {
    *
    * @return {{ spends: SpendableNoteWASM[], anchor: Uint8Array }}
    */
-  buildSpendableNotes (notes: ShieldedEncryptedNote[], recovered: RecoveredNoteWASM[]): { spends: SpendableNoteWASM[], anchor: Uint8Array } {
+  buildSpendableNotes(notes: ShieldedEncryptedNote[], recovered: RecoveredNoteWASM[]): {
+    spends: SpendableNoteWASM[],
+    anchor: Uint8Array
+  } {
     // only the leaves we intend to witness need to be marked spendable
     const spendableIndices = new Set(recovered.map(note => note.index))
 
@@ -195,7 +200,7 @@ export class ShieldedController {
       return new SpendableNoteWASM(recoveredNote.note, merklePath)
     })
 
-    return { spends, anchor }
+    return {spends, anchor}
   }
 
   /**
@@ -216,10 +221,10 @@ export class ShieldedController {
    *
    * @return {StateTransitionWASM}
    */
-  createStateTransition<K extends ShieldedTransitionType> (
+  async createStateTransition<K extends ShieldedTransitionType>(
     type: K,
     params: ShieldedTransitionParamsMap[K]
-  ): StateTransitionWASM {
+  ): Promise<StateTransitionWASM> {
     // @ts-expect-error a plain string memo is normalized to ShieldedMemoWASM (empty when omitted)
     params.memo = typeof params.memo === 'string' ? ShieldedMemoWASM.fromString(params.memo) : ShieldedMemoWASM.empty()
 
@@ -228,10 +233,10 @@ export class ShieldedController {
 
       // @ts-expect-error builder expects IdentityPublicKeyInCreationWASM instances
       identityParams.publicKeys = identityParams.publicKeys
-        .map(({ id, purpose, securityLevel, keyType, readOnly, data, signature, contractBounds }) =>
+        .map(({id, purpose, securityLevel, keyType, readOnly, data, signature, contractBounds}) =>
           new IdentityPublicKeyInCreationWASM(id, purpose, securityLevel, keyType, readOnly, data, signature, (contractBounds != null) ? new ContractBoundsWASM(contractBounds.dataContractId, contractBounds.documentType) : undefined))
     }
 
-    return createStateTransition(this.getShieldedBuilder(), type, params)
+    return await createStateTransition(await this.getShieldedBuilder(), type, params)
   }
 }

--- a/test/unit/Shielded.spec.ts
+++ b/test/unit/Shielded.spec.ts
@@ -68,9 +68,10 @@ function makeSpendableNote(seed: Uint8Array, value: bigint): {
 }
 
 describe('Shielded', () => {
-  beforeAll(() => {
+  beforeAll(async () => {
     sdk = new DashPlatformSDK({network: 'testnet'})
-  })
+    await sdk.shielded.init()
+  }, 60000)
 
   test('getShieldedNotesCount', async () => {
     const count = await sdk.shielded.getShieldedNotesCount()
@@ -145,7 +146,7 @@ describe('Shielded', () => {
     expect(recovered).toHaveLength(0)
   })
 
-  test('buildSpendableNotes produces a spend usable by a transition', () => {
+  test('buildSpendableNotes produces a spend usable by a transition', async () => {
     const seed = randomBytes(32)
     const owner = OrchardAddressWASM.fromSeed(seed, COIN_TYPE, ACCOUNT)
 
@@ -167,7 +168,7 @@ describe('Shielded', () => {
     expect(anchor).toBeInstanceOf(Uint8Array)
 
     // the produced spend + anchor must actually prove a spend transition
-    const stateTransition = sdk.shielded.createStateTransition('shieldedTransfer', {
+    const stateTransition = await sdk.shielded.createStateTransition('shieldedTransfer', {
       spends,
       recipient: OrchardAddressWASM.fromSeed(randomBytes(32), COIN_TYPE, ACCOUNT),
       transferAmount: BigInt(1000000),
@@ -182,13 +183,13 @@ describe('Shielded', () => {
   }, 60000)
 
   describe('should be able to create state transition', () => {
-    test('should be able to create a shield transition', () => {
+    test('should be able to create a shield transition', async () => {
       const seed = randomBytes(32)
       const recipient = OrchardAddressWASM.fromSeed(seed, COIN_TYPE, ACCOUNT)
       const privateKey = new PrivateKeyWASM(randomBytes(32), 'testnet')
       const address = platformAddress(privateKey.getPublicKey().hash160())
 
-      const stateTransition = sdk.shielded.createStateTransition('shield', {
+      const stateTransition = await sdk.shielded.createStateTransition('shield', {
         recipient,
         shieldAmount: BigInt(50000000),
         inputs: [new InputAddressWASM(address, 0, BigInt(100000000))],
@@ -201,14 +202,14 @@ describe('Shielded', () => {
       expect(stateTransition).toEqual(expect.any(StateTransitionWASM))
     }, 60000)
 
-    test('should be able to create a shieldFromAssetLock transition', () => {
+    test('should be able to create a shieldFromAssetLock transition', async () => {
       const seed = randomBytes(32)
       const recipient = OrchardAddressWASM.fromSeed(seed, COIN_TYPE, ACCOUNT)
       const privateKey = PrivateKeyWASM.fromHex('edd04a71bddb31e530f6c2314fd42ada333f6656bb853ece13f0577a8fd30612', 'testnet')
       const txid = '61aede830477254876d435a317241ad46753c4b1350dc991a45ebcf19ab80a11'
       const assetLockProof = AssetLockProofWASM.createChainAssetLockProof(1337, new OutPointWASM(txid, 0))
 
-      const stateTransition = sdk.shielded.createStateTransition('shieldFromAssetLock', {
+      const stateTransition = await sdk.shielded.createStateTransition('shieldFromAssetLock', {
         recipient,
         shieldAmount: BigInt(50000000),
         assetLockProof,
@@ -220,12 +221,12 @@ describe('Shielded', () => {
       expect(stateTransition).toEqual(expect.any(StateTransitionWASM))
     }, 60000)
 
-    test('should be able to create a shieldedTransfer transition', () => {
+    test('should be able to create a shieldedTransfer transition', async () => {
       const seed = randomBytes(32)
       const {spend, anchor, owner} = makeSpendableNote(seed, BigInt(10000000000))
       const recipient = OrchardAddressWASM.fromSeed(randomBytes(32), COIN_TYPE, ACCOUNT)
 
-      const stateTransition = sdk.shielded.createStateTransition('shieldedTransfer', {
+      const stateTransition = await sdk.shielded.createStateTransition('shieldedTransfer', {
         spends: [spend],
         recipient,
         transferAmount: BigInt(1000000),
@@ -240,11 +241,11 @@ describe('Shielded', () => {
       expect(stateTransition).toEqual(expect.any(StateTransitionWASM))
     }, 60000)
 
-    test('should be able to create an unshield transition', () => {
+    test('should be able to create an unshield transition', async () => {
       const seed = randomBytes(32)
       const {spend, anchor, owner} = makeSpendableNote(seed, BigInt(10000000000))
 
-      const stateTransition = sdk.shielded.createStateTransition('unshield', {
+      const stateTransition = await sdk.shielded.createStateTransition('unshield', {
         spends: [spend],
         outputAddress: platformAddress(),
         unshieldAmount: BigInt(1000000),
@@ -259,11 +260,11 @@ describe('Shielded', () => {
       expect(stateTransition).toEqual(expect.any(StateTransitionWASM))
     }, 60000)
 
-    test('should be able to create a shieldedWithdrawal transition', () => {
+    test('should be able to create a shieldedWithdrawal transition', async () => {
       const seed = randomBytes(32)
       const {spend, anchor, owner} = makeSpendableNote(seed, BigInt(10000000000))
 
-      const stateTransition = sdk.shielded.createStateTransition('shieldedWithdrawal', {
+      const stateTransition = await sdk.shielded.createStateTransition('shieldedWithdrawal', {
         spends: [spend],
         withdrawalAmount: BigInt(1000000),
         outputScript: CoreScriptWASM.newP2PKH(randomBytes(20)),
@@ -283,7 +284,7 @@ describe('Shielded', () => {
     // The proving step succeeds, but `IdentityCreateFromShieldedPoolResultWASM.identityId`
     // (read while assembling the transition) rejects the derived id for synthetic notes.
     // A real run needs a funded note and signed keys, so this is covered against a live pool.
-    test('should be able to create an identityCreateFromShieldedPool transition', () => {
+    test('should be able to create an identityCreateFromShieldedPool transition', async () => {
       const seed = randomBytes(32)
       const {spend, anchor, owner} = makeSpendableNote(seed, BigInt(20000000000))
 
@@ -297,7 +298,7 @@ describe('Shielded', () => {
         data: privateKey.getPublicKey().bytes()
       }
 
-      const stateTransition = sdk.shielded.createStateTransition('identityCreateFromShieldedPool', {
+      const stateTransition = await sdk.shielded.createStateTransition('identityCreateFromShieldedPool', {
         publicKeys: [identityPublicKeyInCreation],
         privateKeys: [privateKey],
         denomination: BigInt(10000000000),

--- a/yarn.lock
+++ b/yarn.lock
@@ -1671,10 +1671,15 @@
   resolved "https://registry.npmjs.org/@protobuf-ts/runtime/-/runtime-2.11.1.tgz"
   integrity sha512-KuDaT1IfHkugM2pyz+FwiY80ejWrkH1pAtOBOZFuR6SXEFTsnb/jiQWQ1rCIrcKx2BtyxnxW6BWwsVSA/Ie+WQ==
 
-"@rollup/plugin-commonjs@^28.0.6":
-  version "28.0.6"
-  resolved "https://registry.npmjs.org/@rollup/plugin-commonjs/-/plugin-commonjs-28.0.6.tgz"
-  integrity sha512-XSQB1K7FUU5QP+3lOQmVCE3I0FcbbNvmNT4VJSj93iUjayaARrTQeoRdiYQoftAJBLrR9t2agwAd3ekaTgHNlw==
+"@rollup/plugin-alias@^6.0.0":
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/@rollup/plugin-alias/-/plugin-alias-6.0.0.tgz#f7fa8c806db9c073baa6b00e4b1c396edef9beb2"
+  integrity sha512-tPCzJOtS7uuVZd+xPhoy5W4vThe6KWXNmsFCNktaAh5RTqcLiSfT4huPQIXkgJ6YCOjJHvecOAzQxLFhPxKr+g==
+
+"@rollup/plugin-commonjs@^29.0.3":
+  version "29.0.3"
+  resolved "https://registry.yarnpkg.com/@rollup/plugin-commonjs/-/plugin-commonjs-29.0.3.tgz#e0269126503d218e81e180478355ff740ca9baff"
+  integrity sha512-ZaOxZceP7SOUW7Lqw5IRVweSQYWaeIPnXIGLiB690EBA3FGJTO40EEr2L5yZplJWsgTCogILRSpcAe7+U0Otdg==
   dependencies:
     "@rollup/pluginutils" "^5.0.1"
     commondir "^1.0.1"
@@ -5243,10 +5248,10 @@ protoc@^32.1.0:
   resolved "https://registry.npmjs.org/protoc/-/protoc-32.1.0.tgz"
   integrity sha512-yICJJCGHJLM9ao5W2V4CGp1d7xuBsdHzgVDw6L8mdDtoIcqzN3arNPOm9Jx4Ufp5vfhQfJGkNUDo6mm/SLPdXw==
 
-pshenmic-dpp@2.0.0-dev.23:
-  version "2.0.0-dev.23"
-  resolved "https://registry.yarnpkg.com/pshenmic-dpp/-/pshenmic-dpp-2.0.0-dev.23.tgz#bbc798486d10d304c57bea157953642c7ea77ee4"
-  integrity sha512-Q/fvDf6PZIsLPhKTbmKReSyRUjgFcjTtvucFJlfdfSO85frMLxF7BAL3iKWrtW180IvJNEAFE/I3QBlvGjAwJQ==
+pshenmic-dpp@2.0.0-dev.24:
+  version "2.0.0-dev.24"
+  resolved "https://registry.yarnpkg.com/pshenmic-dpp/-/pshenmic-dpp-2.0.0-dev.24.tgz#ee5cdee6b259555f19e04fc06cb0db4e24c194a6"
+  integrity sha512-879QwY8YSwGtf4XmWo6Q5V8ajh9W66rJQFHYzux0m3JaG2C8BBfdr0QHIwpMaU2SpTNosV9ugS6ZFyZVmkHhbA==
   dependencies:
     "@emnapi/core" "1.9.0"
     "@emnapi/runtime" "1.9.0"


### PR DESCRIPTION
# Issue
After previous release wasm bin stop works, because halo2 proofs is multithreading and withou async workers we cannot call halo2 proofs methods

# Things don
- [Updated pshenmic-dpp](https://github.com/owl352/pshenmic-dpp/pull/190) by performance optimization and a lot of fixes for wasm bin
- Fixed incorrect rollup which generate incorrect `*.min.js`
- Now all shielded builder methods is async
- Update tests
- Bump package version