### PR TITLE
feat: add transparent platform address derivation to keyPair

### DIFF
--- a/src/keyPair/index.ts
+++ b/src/keyPair/index.ts
@@ -4,27 +4,11 @@ import deriveChild from './deriveChild.js'
 import derivePath from './derivePath.js'
 import { Network } from '../../types.js'
 import { p2pkh } from '@scure/btc-signer'
-import { OrchardAddressWASM, orchardOvkFromSeed, PlatformAddressWASM, PublicKeyWASM, PrivateKeyWASM } from 'pshenmic-dpp'
-import hexToBytes from '../utils/hexToBytes.js'
+import { OrchardAddressWASM, orchardOvkFromSeed, PlatformAddressWASM, PrivateKeyWASM } from 'pshenmic-dpp'
 
 const DASH_VERSIONS = {
   mainnet: { pubKeyHash: 0x4c, scriptHash: 0x10, bech32: 'dc', wif: 0xcc, private: 0x0488ade4, public: 0x0488b21e },
   testnet: { pubKeyHash: 0x8c, scriptHash: 0x13, bech32: 'dc', wif: 0xef, private: 0x04358394, public: 0x043587cf }
-}
-
-// DIP-17 transparent platform-address derivation path:
-// m/9'/coinType'/17'/account'/keyClass'/index. keyClass 0 = clear funds.
-const PLATFORM_ADDRESS_FEATURE = 17
-const PLATFORM_ADDRESS_KEY_CLASS_CLEAR_FUNDS = 0
-// PlatformAddressWASM payload variant byte: 0x00 = P2PKH, 0x01 = P2SH.
-const PLATFORM_ADDRESS_P2PKH_VARIANT_BYTE = 0x00
-
-// Encode a transparent platform P2PKH address (DIP-18) from a Hash160 pubkey
-// hash (hex), producing the canonical `variantByte || hash` PlatformAddress.
-const platformAddressFromPublicKeyHash = (pubKeyHashHex: string): PlatformAddressWASM => {
-  const payload = Uint8Array.from([PLATFORM_ADDRESS_P2PKH_VARIANT_BYTE, ...hexToBytes(pubKeyHashHex)])
-
-  return PlatformAddressWASM.fromBytes(payload)
 }
 
 /**
@@ -116,6 +100,22 @@ export class KeyPairController {
   }
 
   /**
+   * Converts a public key to a transparent platform P2PKH address (DIP-18):
+   * the canonical `variantByte || Hash160(pubkey)` PlatformAddress.
+   *
+   * @param publicKey {Uint8Array}
+   * @param network {Network}
+   *
+   * @returns {PlatformAddressWASM}
+   */
+  platformAddress (publicKey: Uint8Array, network: Network): PlatformAddressWASM {
+    const { hash } = p2pkh(publicKey, DASH_VERSIONS[network])
+
+    // variant byte 0x00 = P2PKH
+    return PlatformAddressWASM.fromBytes(Uint8Array.from([0x00, ...hash]))
+  }
+
+  /**
    * Derives a shielded (Orchard) address from a BIP-39 seed via ZIP-32
    * (m/32'/coinType'/account').
    *
@@ -168,7 +168,7 @@ export class KeyPairController {
     const coinType = network === 'mainnet' ? 5 : 1
     const hdKey = this.seedToHdKey(seed, network)
 
-    const accountNode = await this.derivePath(hdKey, `m/9'/${coinType}'/${PLATFORM_ADDRESS_FEATURE}'/${account}'/${PLATFORM_ADDRESS_KEY_CLASS_CLEAR_FUNDS}'`)
+    const accountNode = await this.derivePath(hdKey, `m/9'/${coinType}'/17'/${account}'/0'`)
 
     return accountNode.publicExtendedKey
   }
@@ -188,13 +188,13 @@ export class KeyPairController {
     const coinType = network === 'mainnet' ? 5 : 1
     const hdKey = this.seedToHdKey(seed, network)
 
-    const childNode = await this.derivePath(hdKey, `m/9'/${coinType}'/${PLATFORM_ADDRESS_FEATURE}'/${account}'/${PLATFORM_ADDRESS_KEY_CLASS_CLEAR_FUNDS}'/${index}`)
+    const childNode = await this.derivePath(hdKey, `m/9'/${coinType}'/17'/${account}'/0'/${index}`)
 
     if (childNode.publicKey == null) {
       throw new Error(`Could not derive platform address public key at index ${index}`)
     }
 
-    return platformAddressFromPublicKeyHash(PublicKeyWASM.fromBytes(childNode.publicKey).getPublicKeyHash())
+    return this.platformAddress(childNode.publicKey, network)
   }
 
   /**
@@ -217,7 +217,7 @@ export class KeyPairController {
       throw new Error(`Could not derive platform address public key at index ${index}`)
     }
 
-    return platformAddressFromPublicKeyHash(PublicKeyWASM.fromBytes(childNode.publicKey).getPublicKeyHash())
+    return this.platformAddress(childNode.publicKey, network)
   }
 
   /**
@@ -235,7 +235,7 @@ export class KeyPairController {
   async derivePlatformAddressPrivateKey (seed: Uint8Array, network: Network, account: number, index: number): Promise<PrivateKeyWASM> {
     const coinType = network === 'mainnet' ? 5 : 1
     const hdKey = this.seedToHdKey(seed, network)
-    const path = `m/9'/${coinType}'/${PLATFORM_ADDRESS_FEATURE}'/${account}'/${PLATFORM_ADDRESS_KEY_CLASS_CLEAR_FUNDS}'/${index}`
+    const path = `m/9'/${coinType}'/17'/${account}'/0'/${index}`
 
     const { privateKey } = await this.derivePath(hdKey, path)
 

--- a/src/keyPair/index.ts
+++ b/src/keyPair/index.ts
@@ -4,11 +4,27 @@ import deriveChild from './deriveChild.js'
 import derivePath from './derivePath.js'
 import { Network } from '../../types.js'
 import { p2pkh } from '@scure/btc-signer'
-import { OrchardAddressWASM, orchardOvkFromSeed } from 'pshenmic-dpp'
+import { OrchardAddressWASM, orchardOvkFromSeed, PlatformAddressWASM, PublicKeyWASM, PrivateKeyWASM } from 'pshenmic-dpp'
+import hexToBytes from '../utils/hexToBytes.js'
 
 const DASH_VERSIONS = {
   mainnet: { pubKeyHash: 0x4c, scriptHash: 0x10, bech32: 'dc', wif: 0xcc, private: 0x0488ade4, public: 0x0488b21e },
   testnet: { pubKeyHash: 0x8c, scriptHash: 0x13, bech32: 'dc', wif: 0xef, private: 0x04358394, public: 0x043587cf }
+}
+
+// DIP-17 transparent platform-address derivation path:
+// m/9'/coinType'/17'/account'/keyClass'/index. keyClass 0 = clear funds.
+const PLATFORM_ADDRESS_FEATURE = 17
+const PLATFORM_ADDRESS_KEY_CLASS_CLEAR_FUNDS = 0
+// PlatformAddressWASM payload variant byte: 0x00 = P2PKH, 0x01 = P2SH.
+const PLATFORM_ADDRESS_P2PKH_VARIANT_BYTE = 0x00
+
+// Encode a transparent platform P2PKH address (DIP-18) from a Hash160 pubkey
+// hash (hex), producing the canonical `variantByte || hash` PlatformAddress.
+const platformAddressFromPublicKeyHash = (pubKeyHashHex: string): PlatformAddressWASM => {
+  const payload = Uint8Array.from([PLATFORM_ADDRESS_P2PKH_VARIANT_BYTE, ...hexToBytes(pubKeyHashHex)])
+
+  return PlatformAddressWASM.fromBytes(payload)
 }
 
 /**
@@ -133,5 +149,100 @@ export class KeyPairController {
     const coinType = network === 'mainnet' ? 5 : 1
 
     return orchardOvkFromSeed(seed, coinType, account)
+  }
+
+  /**
+   * Derives the DIP-17 account-level extended public key (xpub) for the
+   * clear-funds key class: m/9'/coinType'/17'/account'/0'. The seed is only
+   * needed once per account — the returned xpub derives every address index
+   * publicly (see {@link derivePlatformAddressFromXpub}), with no further access
+   * to the seed.
+   *
+   * @param seed {Uint8Array} - BIP-39 seed bytes
+   * @param network {Network} - network (selects the SLIP-44 coin type)
+   * @param account {number} - DIP-17 account index
+   *
+   * @returns {Promise<string>} account-level extended public key
+   */
+  async derivePlatformAccountXpub (seed: Uint8Array, network: Network, account: number): Promise<string> {
+    const coinType = network === 'mainnet' ? 5 : 1
+    const hdKey = this.seedToHdKey(seed, network)
+
+    const accountNode = await this.derivePath(hdKey, `m/9'/${coinType}'/${PLATFORM_ADDRESS_FEATURE}'/${account}'/${PLATFORM_ADDRESS_KEY_CLASS_CLEAR_FUNDS}'`)
+
+    return accountNode.publicExtendedKey
+  }
+
+  /**
+   * Derives a transparent platform P2PKH address from a BIP-39 seed via DIP-17
+   * (m/9'/coinType'/17'/account'/0'/index).
+   *
+   * @param seed {Uint8Array} - BIP-39 seed bytes
+   * @param network {Network} - network (selects the SLIP-44 coin type)
+   * @param account {number} - DIP-17 account index
+   * @param index {number} - address index
+   *
+   * @returns {Promise<PlatformAddressWASM>}
+   */
+  async derivePlatformAddress (seed: Uint8Array, network: Network, account: number, index: number): Promise<PlatformAddressWASM> {
+    const coinType = network === 'mainnet' ? 5 : 1
+    const hdKey = this.seedToHdKey(seed, network)
+
+    const childNode = await this.derivePath(hdKey, `m/9'/${coinType}'/${PLATFORM_ADDRESS_FEATURE}'/${account}'/${PLATFORM_ADDRESS_KEY_CLASS_CLEAR_FUNDS}'/${index}`)
+
+    if (childNode.publicKey == null) {
+      throw new Error(`Could not derive platform address public key at index ${index}`)
+    }
+
+    return platformAddressFromPublicKeyHash(PublicKeyWASM.fromBytes(childNode.publicKey).getPublicKeyHash())
+  }
+
+  /**
+   * Derives a transparent platform P2PKH address from an account-level xpub (see
+   * {@link derivePlatformAccountXpub}). The address index is non-hardened, so
+   * public-only derivation reproduces the exact same address as the seed-based
+   * path — no seed required.
+   *
+   * @param xpub {string} - account-level extended public key
+   * @param network {Network} - network (selects the extended-key version bytes)
+   * @param index {number} - address index
+   *
+   * @returns {PlatformAddressWASM}
+   */
+  derivePlatformAddressFromXpub (xpub: string, network: Network, index: number): PlatformAddressWASM {
+    const accountNode = HDKey.fromExtendedKey(xpub, DASH_VERSIONS[network])
+    const childNode = accountNode.deriveChild(index)
+
+    if (childNode.publicKey == null) {
+      throw new Error(`Could not derive platform address public key at index ${index}`)
+    }
+
+    return platformAddressFromPublicKeyHash(PublicKeyWASM.fromBytes(childNode.publicKey).getPublicKeyHash())
+  }
+
+  /**
+   * Derives the private key for a DIP-17 platform address by its index
+   * (m/9'/coinType'/17'/account'/0'/index). Used to sign a transfer that spends
+   * from that address.
+   *
+   * @param seed {Uint8Array} - BIP-39 seed bytes
+   * @param network {Network} - network (selects the SLIP-44 coin type)
+   * @param account {number} - DIP-17 account index
+   * @param index {number} - address index
+   *
+   * @returns {Promise<PrivateKeyWASM>}
+   */
+  async derivePlatformAddressPrivateKey (seed: Uint8Array, network: Network, account: number, index: number): Promise<PrivateKeyWASM> {
+    const coinType = network === 'mainnet' ? 5 : 1
+    const hdKey = this.seedToHdKey(seed, network)
+    const path = `m/9'/${coinType}'/${PLATFORM_ADDRESS_FEATURE}'/${account}'/${PLATFORM_ADDRESS_KEY_CLASS_CLEAR_FUNDS}'/${index}`
+
+    const { privateKey } = await this.derivePath(hdKey, path)
+
+    if (privateKey == null) {
+      throw new Error(`Could not derive platform address key at ${path}`)
+    }
+
+    return PrivateKeyWASM.fromBytes(privateKey, network)
   }
 }

--- a/test/unit/KeyPair.spec.ts
+++ b/test/unit/KeyPair.spec.ts
@@ -1,4 +1,4 @@
-import { OrchardAddressWASM } from 'pshenmic-dpp'
+import { OrchardAddressWASM, PlatformAddressWASM } from 'pshenmic-dpp'
 import { DashPlatformSDK } from '../../src/DashPlatformSDK.js'
 
 let sdk: DashPlatformSDK
@@ -87,6 +87,71 @@ describe('KeyPair', () => {
       expect(ovk).toHaveLength(32)
       // deterministic for the same seed/network/account
       expect(ovk).toEqual(sdk.keyPair.deriveShieldedOutgoingViewingKey(seed, 'testnet', account))
+    })
+  })
+
+  describe('platform addresses', () => {
+    const account = 0
+
+    // Reference values produced by the dash-platform-extension derivation utils
+    // (proven byte-identical to on-chain / desktop-wallet addresses) for the
+    // fixed mnemonic above, testnet, account 0.
+    const expectedXpub = 'tpubDH6WaqMU1YHJMbPG413my6Dx5DwnsuuL6EzbetEZQac6ixmkByzCGgiibue3HQmHX5JGVUm2fBHKGttJpVkx3NrK5Em9br8GyLd1fVGm7ud'
+    const expectedAddresses = [
+      'tdash1kr0xt5wj85ht5u464rfysjrq75rewz9mysjwf59p',
+      'tdash1kqgy7ngm2wf0zsv20k4mc62s5rapw26yeg6em4jq',
+      'tdash1kzlatzl0u06uxrqz8hkc7naz9d2g3v8g7gw83ew3'
+    ]
+
+    test('derives the DIP-17 account xpub matching the reference', async () => {
+      const seed = sdk.keyPair.mnemonicToSeed(mnemonic)
+
+      const xpub = await sdk.keyPair.derivePlatformAccountXpub(seed, 'testnet', account)
+
+      expect(xpub).toEqual(expectedXpub)
+    })
+
+    test('derives seed-based addresses matching the reference', async () => {
+      const seed = sdk.keyPair.mnemonicToSeed(mnemonic)
+
+      for (let index = 0; index < expectedAddresses.length; index++) {
+        const address = await sdk.keyPair.derivePlatformAddress(seed, 'testnet', account, index)
+
+        expect(address).toEqual(expect.any(PlatformAddressWASM))
+        expect(address.isP2PKH()).toBe(true)
+        expect(address.toBech32m('testnet')).toEqual(expectedAddresses[index])
+      }
+    })
+
+    test('xpub-based public derivation reproduces the seed-based addresses', async () => {
+      const seed = sdk.keyPair.mnemonicToSeed(mnemonic)
+      const xpub = await sdk.keyPair.derivePlatformAccountXpub(seed, 'testnet', account)
+
+      for (let index = 0; index < expectedAddresses.length; index++) {
+        const fromXpub = sdk.keyPair.derivePlatformAddressFromXpub(xpub, 'testnet', index)
+
+        expect(fromXpub.toBech32m('testnet')).toEqual(expectedAddresses[index])
+      }
+    })
+
+    test('private key derivation yields the same pubkey hash as the address', async () => {
+      const seed = sdk.keyPair.mnemonicToSeed(mnemonic)
+
+      for (let index = 0; index < expectedAddresses.length; index++) {
+        const privateKey = await sdk.keyPair.derivePlatformAddressPrivateKey(seed, 'testnet', account, index)
+        const address = await sdk.keyPair.derivePlatformAddress(seed, 'testnet', account, index)
+
+        expect(privateKey.getPublicKeyHash()).toEqual(Buffer.from(address.hash()).toString('hex'))
+      }
+    })
+
+    test('derives distinct addresses per network', async () => {
+      const seed = sdk.keyPair.mnemonicToSeed(mnemonic)
+
+      const mainnet = await sdk.keyPair.derivePlatformAddress(seed, 'mainnet', account, 0)
+      const testnet = await sdk.keyPair.derivePlatformAddress(seed, 'testnet', account, 0)
+
+      expect(mainnet.bytes()).not.toEqual(testnet.bytes())
     })
   })
 })


### PR DESCRIPTION
Adds DIP-17 transparent platform-address derivation to `keyPair`, mirroring the existing `deriveShieldedAddress` pattern. Previously only Orchard shielded derivation existed in the SDK; transparent platform-address derivation was duplicated in downstream consumers.

## New `KeyPairController` methods
- `derivePlatformAccountXpub(seed, network, account)` — DIP-17 account xpub `m/9'/coin'/17'/account'/0'`; derived once per account, then derives every index publicly.
- `derivePlatformAddress(seed, network, account, index)` — seed-based leaf `PlatformAddressWASM`.
- `derivePlatformAddressFromXpub(xpub, network, index)` — public (password-free) derivation from the account xpub; reproduces the seed-based address.
- `derivePlatformAddressPrivateKey(seed, network, account, index)` — leaf `PrivateKeyWASM` for signing.

Encoding uses the canonical `variantByte(0x00 P2PKH) || Hash160(pubkey)` via `PlatformAddressWASM.fromBytes`.

## Tests
`test/unit/KeyPair.spec.ts` — known-answer vectors (testnet, account 0): account xpub + addresses 0–2, cross-checked byte-for-byte against a downstream implementation proven equivalent to on-chain / desktop-wallet addresses. Covers seed↔xpub consistency, private-key↔address hash match, and per-network distinctness.