### PR TITLE
Bump package version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dash-platform-sdk",
-  "version": "1.5.0-dev.4",
+  "version": "1.5.0-dev.5",
   "main": "index.js",
   "description": "Lightweight SDK for accessing Dash Platform blockchain",
   "repository": {


### PR DESCRIPTION
# Issue
Before release sdk version must be bumped to `1.5.0-dev.5` in `package.json`

# Things done
- Bumped package version