### PR TITLE
Make outputScript optional for withdrawals

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# dash-platform-sdk v1.5.0
+# dash-platform-sdk v1.5.0-dev.7
 [![GitHub license](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/pshenmic/dash-platform-sdk/blob/master/LICENSE) ![npm version](https://img.shields.io/npm/v/react.svg?style=flat) ![a](https://github.com/pshenmic/platform-explorer/actions/workflows/build.yml/badge.svg)
 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dash-platform-sdk",
-  "version": "1.5.0-dev.6",
+  "version": "1.5.0-dev.7",
   "main": "index.js",
   "description": "Lightweight SDK for accessing Dash Platform blockchain",
   "repository": {

--- a/src/identities/createStateTransition.ts
+++ b/src/identities/createStateTransition.ts
@@ -32,7 +32,7 @@ const identityTransitionsMap = {
   withdrawal: {
     class: IdentityCreditWithdrawalTransitionWASM,
     arguments: ['identityId', 'amount', 'coreFeePerByte', 'pooling', 'identityNonce', 'outputScript'],
-    optionalArguments: ['userFeeIncrease']
+    optionalArguments: ['outputScript', 'userFeeIncrease']
   }
 }
 
@@ -48,7 +48,7 @@ export default function createStateTransition (type: 'create' | 'update' | 'topU
           !(optionalArguments).includes(classArgument))
 
   if (missingArgument != null) {
-    throw new Error(`Token transition param "${missingArgument}" is missing`)
+    throw new Error(`Transition param "${missingArgument}" is missing`)
   }
 
   const transitionParams = classArguments.map((classArgument: string) => params[classArgument])

--- a/src/utils/verifyTenderdashProof.ts
+++ b/src/utils/verifyTenderdashProof.ts
@@ -5,6 +5,10 @@ import { verifySignatureDigest } from 'pshenmic-dpp'
 import hexToBytes from './hexToBytes.js'
 
 export default async function verifyTenderdashProof (proof: Proof, metadata: ResponseMetadata, rootHash: Uint8Array, quorumPublicKey: string): Promise<boolean> {
+  if ((new Date().getTime() - new Date(metadata.timeMs).getTime()) > 15 * 60 * 60 * 1000) {
+    throw new Error('Request is stalled (over 15 minutes)')
+  }
+
   const stateId = StateId.create({
     appVersion: String(metadata.protocolVersion),
     coreChainLockedHeight: metadata.coreChainLockedHeight,

--- a/test/unit/Identity.spec.ts
+++ b/test/unit/Identity.spec.ts
@@ -326,7 +326,7 @@ describe('Identity', () => {
       const amount = 100000n
       const identityNonce = await sdk.identities.getIdentityNonce(identityId)
 
-      const stateTransition = sdk.identities.createStateTransition('creditTransfer', { identityId, recipientId, amount, identityNonce })
+      const stateTransition = sdk.identities.createStateTransition('withdrawal', { identityId, recipientId, amount, identityNonce })
 
       expect(stateTransition).toEqual(expect.any(StateTransitionWASM))
     })


### PR DESCRIPTION
# Issue

SDK did not allow withdrawals to omit outputScript (this is necessary for masternode identity withdrawals), and the test was written incorrectly.

We also found that SDK does not check for stalled requests for DAPI and it should throw a error for such requests instead.


# Things done

* Added check for stalled DAPI requests (over 15 minutes)
* Made outputScript optional for identity credit withdrawals
* Bumped package version to 1.5.0-dev.7